### PR TITLE
Property: add support for example

### DIFF
--- a/src/Annotation/Property.php
+++ b/src/Annotation/Property.php
@@ -21,4 +21,9 @@ final class Property
      * @var bool
      */
     public ?bool $required = null;
+
+    /**
+     * @var string JSON formatted example
+     */
+    public ?string $example = null;
 }

--- a/src/Exception/ExampleValidationException.php
+++ b/src/Exception/ExampleValidationException.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ScrumWorks\OpenApiSchema\Exception;
+
+use ScrumWorks\OpenApiSchema\Validation\ValidationResultInterface;
+use Throwable;
+
+class ExampleValidationException extends LogicException
+{
+    private ?ValidationResultInterface $validationResult;
+
+    public function __construct(
+        $message = '',
+        $code = 0,
+        ?Throwable $previous = null,
+        ?ValidationResultInterface $validationResult = null
+    ) {
+        parent::__construct($message, $code, $previous);
+
+        $this->validationResult = $validationResult;
+    }
+
+    public function getValidationResult(): ?ValidationResultInterface
+    {
+        return $this->validationResult;
+    }
+}

--- a/src/OpenApiTranslator.php
+++ b/src/OpenApiTranslator.php
@@ -195,8 +195,11 @@ class OpenApiTranslator implements OpenApiTranslatorInterface
         if ($schema->isNullable()) {
             $definition['nullable'] = true;
         }
-        if ($schema->getDescription()) {
+        if ($schema->getDescription() !== null) {
             $definition['description'] = $schema->getDescription();
+        }
+        if ($schema->getExample() !== null) {
+            $definition['example'] = $schema->getExample();
         }
         return $definition;
     }

--- a/src/ValueSchema/AbstractValueSchema.php
+++ b/src/ValueSchema/AbstractValueSchema.php
@@ -10,10 +10,16 @@ abstract class AbstractValueSchema implements ValueSchemaInterface
 
     protected ?string $description;
 
-    public function __construct(bool $nullable = false, ?string $description = null)
+    /**
+     * @var ?mixed
+     */
+    protected $example;
+
+    public function __construct(bool $nullable = false, ?string $description = null, $example = null)
     {
         $this->nullable = $nullable;
         $this->description = $description;
+        $this->example = $example;
         $this->validate();
     }
 
@@ -25,6 +31,14 @@ abstract class AbstractValueSchema implements ValueSchemaInterface
     public function getDescription(): ?string
     {
         return $this->description;
+    }
+
+    /**
+     * @return ?mixed
+     */
+    public function getExample()
+    {
+        return $this->example;
     }
 
     abstract protected function validate();

--- a/src/ValueSchema/ArraySchema.php
+++ b/src/ValueSchema/ArraySchema.php
@@ -22,14 +22,15 @@ final class ArraySchema extends AbstractValueSchema
         ?int $maxItems = null,
         ?bool $uniqueItems = null,
         bool $nullable = false,
-        ?string $description = null
+        ?string $description = null,
+        $example = null
     ) {
         $this->itemsSchema = $itemsSchema;
         $this->minItems = $minItems;
         $this->maxItems = $maxItems;
         $this->uniqueItems = $uniqueItems;
 
-        parent::__construct($nullable, $description);
+        parent::__construct($nullable, $description, $example);
     }
 
     public function getMinItems(): ?int

--- a/src/ValueSchema/Builder/AbstractSchemaBuilder.php
+++ b/src/ValueSchema/Builder/AbstractSchemaBuilder.php
@@ -15,6 +15,11 @@ abstract class AbstractSchemaBuilder
     protected ?string $description = null;
 
     /**
+     * @var ?mixed
+     */
+    protected $example = null;
+
+    /**
      * @return static
      */
     final public function withNullable(bool $nullable)
@@ -32,6 +37,16 @@ abstract class AbstractSchemaBuilder
         return $this;
     }
 
+    /**
+     * @param ?mixed $example
+     * @return static
+     */
+    final public function withExample($example)
+    {
+        $this->example = $example;
+        return $this;
+    }
+
     public function isNullable(): bool
     {
         return $this->nullable;
@@ -40,6 +55,11 @@ abstract class AbstractSchemaBuilder
     public function getDescription(): ?string
     {
         return $this->description;
+    }
+
+    public function getExample()
+    {
+        return $this->example;
     }
 
     public function build(): ValueSchemaInterface

--- a/src/ValueSchema/Builder/ArraySchemaBuilder.php
+++ b/src/ValueSchema/Builder/ArraySchemaBuilder.php
@@ -91,7 +91,8 @@ final class ArraySchemaBuilder extends AbstractSchemaBuilder
             $this->maxItems,
             $this->uniqueItems,
             $this->nullable,
-            $this->description
+            $this->description,
+            $this->example
         );
     }
 }

--- a/src/ValueSchema/Builder/BooleanSchemaBuilder.php
+++ b/src/ValueSchema/Builder/BooleanSchemaBuilder.php
@@ -13,6 +13,6 @@ final class BooleanSchemaBuilder extends AbstractSchemaBuilder
 {
     protected function createInstance(): BooleanSchema
     {
-        return new BooleanSchema($this->nullable, $this->description);
+        return new BooleanSchema($this->nullable, $this->description, $this->example);
     }
 }

--- a/src/ValueSchema/Builder/EnumSchemaBuilder.php
+++ b/src/ValueSchema/Builder/EnumSchemaBuilder.php
@@ -43,6 +43,6 @@ final class EnumSchemaBuilder extends AbstractSchemaBuilder
 
     protected function createInstance(): EnumSchema
     {
-        return new EnumSchema($this->enum, $this->nullable, $this->description);
+        return new EnumSchema($this->enum, $this->nullable, $this->description, $this->example);
     }
 }

--- a/src/ValueSchema/Builder/FloatSchemaBuilder.php
+++ b/src/ValueSchema/Builder/FloatSchemaBuilder.php
@@ -100,7 +100,8 @@ final class FloatSchemaBuilder extends AbstractSchemaBuilder
             $this->exclusiveMaximum,
             $this->multipleOf,
             $this->nullable,
-            $this->description
+            $this->description,
+            $this->example
         );
     }
 }

--- a/src/ValueSchema/Builder/HashmapSchemaBuilder.php
+++ b/src/ValueSchema/Builder/HashmapSchemaBuilder.php
@@ -63,7 +63,8 @@ final class HashmapSchemaBuilder extends AbstractSchemaBuilder
             $this->itemsSchema,
             $this->requiredProperties,
             $this->nullable,
-            $this->description
+            $this->description,
+            $this->example
         );
     }
 }

--- a/src/ValueSchema/Builder/IntegerSchemaBuilder.php
+++ b/src/ValueSchema/Builder/IntegerSchemaBuilder.php
@@ -100,7 +100,8 @@ final class IntegerSchemaBuilder extends AbstractSchemaBuilder
             $this->exclusiveMaximum,
             $this->multipleOf,
             $this->nullable,
-            $this->description
+            $this->description,
+            $this->example
         );
     }
 }

--- a/src/ValueSchema/Builder/MixedSchemaBuilder.php
+++ b/src/ValueSchema/Builder/MixedSchemaBuilder.php
@@ -13,6 +13,6 @@ final class MixedSchemaBuilder extends AbstractSchemaBuilder
 {
     protected function createInstance(): MixedSchema
     {
-        return new MixedSchema($this->nullable, $this->description);
+        return new MixedSchema($this->nullable, $this->description, $this->example);
     }
 }

--- a/src/ValueSchema/Builder/ObjectSchemaBuilder.php
+++ b/src/ValueSchema/Builder/ObjectSchemaBuilder.php
@@ -64,7 +64,8 @@ final class ObjectSchemaBuilder extends AbstractSchemaBuilder
             $this->propertiesSchemas,
             $this->requiredProperties,
             $this->nullable,
-            $this->description
+            $this->description,
+            $this->example
         );
     }
 }

--- a/src/ValueSchema/Builder/StringSchemaBuilder.php
+++ b/src/ValueSchema/Builder/StringSchemaBuilder.php
@@ -83,7 +83,8 @@ final class StringSchemaBuilder extends AbstractSchemaBuilder
             $this->format,
             $this->pattern,
             $this->nullable,
-            $this->description
+            $this->description,
+            $this->example
         );
     }
 }

--- a/src/ValueSchema/EnumSchema.php
+++ b/src/ValueSchema/EnumSchema.php
@@ -16,11 +16,11 @@ final class EnumSchema extends AbstractValueSchema
     /**
      * @param string[] $enum
      */
-    public function __construct(array $enum, bool $nullable = false, ?string $description = null)
+    public function __construct(array $enum, bool $nullable = false, ?string $description = null, $example = null)
     {
         $this->enum = $enum;
 
-        parent::__construct($nullable, $description);
+        parent::__construct($nullable, $description, $example);
     }
 
     /**

--- a/src/ValueSchema/FloatSchema.php
+++ b/src/ValueSchema/FloatSchema.php
@@ -25,7 +25,8 @@ final class FloatSchema extends AbstractValueSchema
         ?bool $exclusiveMaximum = null,
         ?float $multipleOf = null,
         bool $nullable = false,
-        ?string $description = null
+        ?string $description = null,
+        $example = null
     ) {
         $this->minimum = $minimum;
         $this->maximum = $maximum;
@@ -33,7 +34,7 @@ final class FloatSchema extends AbstractValueSchema
         $this->exclusiveMaximum = $exclusiveMaximum;
         $this->multipleOf = $multipleOf;
 
-        parent::__construct($nullable, $description);
+        parent::__construct($nullable, $description, $example);
     }
 
     public function getMinimum(): ?float

--- a/src/ValueSchema/HashmapSchema.php
+++ b/src/ValueSchema/HashmapSchema.php
@@ -17,12 +17,13 @@ final class HashmapSchema extends AbstractValueSchema
         ValueSchemaInterface $itemsSchema,
         array $requiredProperties = [],
         bool $nullable = false,
-        ?string $description = null
+        ?string $description = null,
+        $example = null
     ) {
         $this->itemsSchema = $itemsSchema;
         $this->requiredProperties = $requiredProperties;
 
-        parent::__construct($nullable, $description);
+        parent::__construct($nullable, $description, $example);
     }
 
     public function getItemsSchema(): ValueSchemaInterface

--- a/src/ValueSchema/IntegerSchema.php
+++ b/src/ValueSchema/IntegerSchema.php
@@ -25,7 +25,8 @@ final class IntegerSchema extends AbstractValueSchema
         ?bool $exclusiveMaximum = null,
         ?int $multipleOf = null,
         bool $nullable = false,
-        ?string $description = null
+        ?string $description = null,
+        $example = null
     ) {
         $this->minimum = $minimum;
         $this->maximum = $maximum;
@@ -33,7 +34,7 @@ final class IntegerSchema extends AbstractValueSchema
         $this->exclusiveMaximum = $exclusiveMaximum;
         $this->multipleOf = $multipleOf;
 
-        parent::__construct($nullable, $description);
+        parent::__construct($nullable, $description, $example);
     }
 
     public function getMinimum(): ?int

--- a/src/ValueSchema/ObjectSchema.php
+++ b/src/ValueSchema/ObjectSchema.php
@@ -26,14 +26,15 @@ final class ObjectSchema extends AbstractValueSchema
         array $propertiesSchemas,
         array $requiredProperties = [],
         bool $nullable = false,
-        ?string $description = null
+        ?string $description = null,
+        $example = null
     ) {
         // TODO: maybe $propertiesSchemas as stdClass?
 
         $this->propertiesSchemas = $propertiesSchemas;
         $this->requiredProperties = $requiredProperties;
 
-        parent::__construct($nullable, $description);
+        parent::__construct($nullable, $description, $example);
     }
 
     /**

--- a/src/ValueSchema/StringSchema.php
+++ b/src/ValueSchema/StringSchema.php
@@ -22,14 +22,15 @@ final class StringSchema extends AbstractValueSchema
         ?string $format = null,
         ?string $pattern = null,
         bool $nullable = false,
-        ?string $description = null
+        ?string $description = null,
+        $example = null
     ) {
         $this->minLength = $minLength;
         $this->maxLength = $maxLength;
         $this->format = $format;
         $this->pattern = $pattern;
 
-        parent::__construct($nullable, $description);
+        parent::__construct($nullable, $description, $example);
     }
 
     public function getMinLength(): ?int

--- a/src/ValueSchema/ValueSchemaInterface.php
+++ b/src/ValueSchema/ValueSchemaInterface.php
@@ -9,4 +9,9 @@ interface ValueSchemaInterface
     public function isNullable(): bool;
 
     public function getDescription(): ?string;
+
+    /**
+     * @return ?mixed
+     */
+    public function getExample();
 }

--- a/tests/OpenApiTranslatorTest.php
+++ b/tests/OpenApiTranslatorTest.php
@@ -47,10 +47,11 @@ class OpenApiTranslatorTest extends TestCase
         return [
             'mixed:minimal' => [new MixedSchema(), []],
             'mixed:full' => [
-                new MixedSchema(true, 'mixed'),
+                new MixedSchema(true, 'mixed', 123),
                 [
                     'nullable' => true,
                     'description' => 'mixed',
+                    'example' => '123',
                 ],
             ],
         ];
@@ -66,7 +67,7 @@ class OpenApiTranslatorTest extends TestCase
                 ],
             ],
             'integer:full' => [
-                new IntegerSchema(0, 10, false, true, 2, false, 'integer'),
+                new IntegerSchema(0, 10, false, true, 2, false, 'integer', 2),
                 [
                     'type' => 'integer',
                     'minimum' => 0,
@@ -75,6 +76,7 @@ class OpenApiTranslatorTest extends TestCase
                     'exclusiveMaximum' => true,
                     'multipleOf' => 2,
                     'description' => 'integer',
+                    'example' => 2,
                 ],
             ],
         ];
@@ -91,7 +93,7 @@ class OpenApiTranslatorTest extends TestCase
                 ],
             ],
             'float:full' => [
-                new FloatSchema(2.2, 2.8, true, false, 0.2, true, 'float'),
+                new FloatSchema(2.2, 2.8, true, false, 0.2, true, 'float', 2.4),
                 [
                     'type' => 'number',
                     'format' => 'float',
@@ -102,6 +104,7 @@ class OpenApiTranslatorTest extends TestCase
                     'multipleOf' => 0.2,
                     'description' => 'float',
                     'nullable' => true,
+                    'example' => 2.4,
                 ],
             ],
         ];
@@ -117,11 +120,12 @@ class OpenApiTranslatorTest extends TestCase
                 ],
             ],
             'boolean:full' => [
-                new BooleanSchema(true, 'boolean'),
+                new BooleanSchema(true, 'boolean', false),
                 [
                     'type' => 'boolean',
                     'description' => 'boolean',
                     'nullable' => true,
+                    'example' => false,
                 ],
             ],
         ];
@@ -137,7 +141,7 @@ class OpenApiTranslatorTest extends TestCase
                 ],
             ],
             'string:full' => [
-                new StringSchema(2, 10, 'email', '[a-z]+', true, 'string'),
+                new StringSchema(2, 10, 'email', '[a-z]+', true, 'string', 'abc'),
                 [
                     'type' => 'string',
                     'minLength' => 2,
@@ -146,6 +150,7 @@ class OpenApiTranslatorTest extends TestCase
                     'pattern' => '[a-z]+',
                     'description' => 'string',
                     'nullable' => true,
+                    'example' => 'abc',
                 ],
             ],
         ];
@@ -170,11 +175,12 @@ class OpenApiTranslatorTest extends TestCase
                 ],
            ],
             'enum:full' => [
-                new EnumSchema(['value', 'value2'], false, 'enum'),
+                new EnumSchema(['value', 'value2'], false, 'enum', 'value2'),
                 [
                     'type' => 'string',
                     'enum' => ['value', 'value2'],
                     'description' => 'enum',
+                    'example' => 'value2',
                 ],
             ],
         ];
@@ -200,7 +206,7 @@ class OpenApiTranslatorTest extends TestCase
                 ],
             ],
             'array:full' => [
-                new ArraySchema(new StringSchema(), 1, 3, true, false, 'array', ),
+                new ArraySchema(new StringSchema(), 1, 3, true, false, 'array', ['a', 'b', 'c']),
                 [
                     'type' => 'array',
                     'items' => [
@@ -210,6 +216,7 @@ class OpenApiTranslatorTest extends TestCase
                     'maxItems' => 3,
                     'uniqueItems' => true,
                     'description' => 'array',
+                    'example' => ['a', 'b', 'c'],
                 ],
             ],
             'array:nested' => [
@@ -248,7 +255,10 @@ class OpenApiTranslatorTest extends TestCase
                 ],
             ],
             'hashmap:full' => [
-                new HashmapSchema(new IntegerSchema(), ['property'], false, 'hashmap'),
+                new HashmapSchema(new IntegerSchema(), ['property'], false, 'hashmap', (object) [
+                    'property' => 1,
+                    'b' => 2,
+                ]),
                 [
                     'type' => 'object',
                     'properties' => [
@@ -261,6 +271,10 @@ class OpenApiTranslatorTest extends TestCase
                         'type' => 'integer',
                     ],
                     'description' => 'hashmap',
+                    'example' => (object) [
+                        'property' => 1,
+                        'b' => 2,
+                    ],
                 ],
             ],
         ];
@@ -293,7 +307,10 @@ class OpenApiTranslatorTest extends TestCase
                 new ObjectSchema([
                     'name' => new StringSchema(),
                     'age' => new IntegerSchema(),
-                ], ['name'], false, 'object'),
+                ], ['name'], false, 'object', (object) [
+                    'name' => 'test',
+                    'age' => 10,
+                ]),
                 [
                     'type' => 'object',
                     'properties' => [
@@ -306,6 +323,10 @@ class OpenApiTranslatorTest extends TestCase
                     ],
                     'required' => ['name'],
                     'description' => 'object',
+                    'example' => (object) [
+                        'name' => 'test',
+                        'age' => 10,
+                    ],
                 ],
             ],
         ];

--- a/tests/PropertySchemaDecorator/AnnotationPropertySchemaDecorator/AbstractAnnotationTest.php
+++ b/tests/PropertySchemaDecorator/AnnotationPropertySchemaDecorator/AbstractAnnotationTest.php
@@ -11,6 +11,11 @@ use ReflectionException;
 use ReflectionProperty;
 use ScrumWorks\OpenApiSchema\PropertySchemaDecorator\AnnotationPropertySchemaDecorator;
 use ScrumWorks\OpenApiSchema\SchemaParser;
+use ScrumWorks\OpenApiSchema\Validation\Result\BreadCrumbPathFactory;
+use ScrumWorks\OpenApiSchema\Validation\Result\ValidationResultBuilderFactory;
+use ScrumWorks\OpenApiSchema\Validation\Result\ValidityViolationFactory;
+use ScrumWorks\OpenApiSchema\Validation\Validator\ValidatorFactory;
+use ScrumWorks\OpenApiSchema\Validation\Validator\ValueSchemaValidator;
 use ScrumWorks\OpenApiSchema\ValueSchema\ValueSchemaInterface;
 use ScrumWorks\PropertyReader\PropertyTypeReader;
 use ScrumWorks\PropertyReader\VariableTypeUnifyService;
@@ -23,9 +28,15 @@ abstract class AbstractAnnotationTest extends TestCase
 
     protected function setUp(): void
     {
+        $valueSchemaValidator = new ValueSchemaValidator(
+            new ValidatorFactory(
+                new BreadCrumbPathFactory(),
+                new ValidationResultBuilderFactory(new ValidityViolationFactory())
+            )
+        );
         $this->schemaParser = new SchemaParser(
-            new PropertyTypeReader(new VariableTypeUnifyService(), ),
-            new AnnotationPropertySchemaDecorator(new AnnotationReader())
+            new PropertyTypeReader(new VariableTypeUnifyService()),
+            new AnnotationPropertySchemaDecorator(new AnnotationReader(), $valueSchemaValidator)
         );
         $this->reflection = $this->createReflectionClass();
     }

--- a/tests/PropertySchemaDecorator/AnnotationPropertySchemaDecorator/ArrayValueTest.php
+++ b/tests/PropertySchemaDecorator/AnnotationPropertySchemaDecorator/ArrayValueTest.php
@@ -15,7 +15,8 @@ use ScrumWorks\OpenApiSchema\ValueSchema\StringSchema;
 class ArrayValueTestClass
 {
     /**
-     * @OA\ArrayValue(minItems=10, maxItems=20, uniqueItems=true)
+     * @OA\ArrayValue(minItems=3, maxItems=20, uniqueItems=true)
+     * @OA\Property(example="[1, 2, 3, 4]")
      */
     public array $array;
 
@@ -42,7 +43,7 @@ class ArrayValueTest extends AbstractAnnotationTest
     public function testArrayAnnotation(): void
     {
         $schema = $this->getPropertySchema('array');
-        $expectedSchema = new ArraySchema(new MixedSchema(true), 10, 20, true);
+        $expectedSchema = new ArraySchema(new MixedSchema(true), 3, 20, true, false, null, [1, 2, 3, 4]);
         $this->assertEquals($expectedSchema, $schema);
     }
 

--- a/tests/PropertySchemaDecorator/AnnotationPropertySchemaDecorator/EnumValueTest.php
+++ b/tests/PropertySchemaDecorator/AnnotationPropertySchemaDecorator/EnumValueTest.php
@@ -13,6 +13,7 @@ class EnumValueTestClass
 {
     /**
      * @OA\EnumValue(enum={"value1", "value2"})
+     * @OA\Property(example="""value1""")
      */
     public string $enum;
 
@@ -33,7 +34,7 @@ class EnumValueTest extends AbstractAnnotationTest
     public function testEnumAnnotation(): void
     {
         $schema = $this->getPropertySchema('enum');
-        $expectedSchema = new EnumSchema(['value1', 'value2']);
+        $expectedSchema = new EnumSchema(['value1', 'value2'], false, null, 'value1');
         $this->assertEquals($expectedSchema, $schema);
     }
 

--- a/tests/PropertySchemaDecorator/AnnotationPropertySchemaDecorator/FloatValueTest.php
+++ b/tests/PropertySchemaDecorator/AnnotationPropertySchemaDecorator/FloatValueTest.php
@@ -13,6 +13,7 @@ class FloatValueTestClass
 {
     /**
      * @OA\FloatValue(minimum=10.2, maximum=100.0, multipleOf=10.1, exclusiveMinimum=true, exclusiveMaximum=false)
+     * @OA\Property(example="30.3")
      */
     public float $float;
 
@@ -27,7 +28,7 @@ class FloatValueTest extends AbstractAnnotationTest
     public function testFloatAnnotation(): void
     {
         $schema = $this->getPropertySchema('float');
-        $expectedSchema = new FloatSchema(10.2, 100.0, true, false, 10.1);
+        $expectedSchema = new FloatSchema(10.2, 100.0, true, false, 10.1, false, null, 30.3);
         $this->assertEquals($expectedSchema, $schema);
     }
 

--- a/tests/PropertySchemaDecorator/AnnotationPropertySchemaDecorator/HashmapValueTest.php
+++ b/tests/PropertySchemaDecorator/AnnotationPropertySchemaDecorator/HashmapValueTest.php
@@ -15,6 +15,7 @@ class HashmapValueTestClass
     /**
      * @var array<string, string>
      * @OA\HashmapValue(requiredProperties={"a", "b"})
+     * @OA\Property(example="{""a"": ""test"", ""b"": ""test2"", ""c"": ""test3""}")
      */
     public array $hashmap;
 
@@ -29,7 +30,17 @@ class HashmapValueTest extends AbstractAnnotationTest
     public function testHashmapAnnotation(): void
     {
         $schema = $this->getPropertySchema('hashmap');
-        $expectedSchema = new HashmapSchema(new StringSchema(), ['a', 'b']);
+        $expectedSchema = new HashmapSchema(
+            new StringSchema(),
+            ['a', 'b'],
+            false,
+            null,
+            (object) [
+                'a' => 'test',
+                'b' => 'test2',
+                'c' => 'test3',
+            ]
+        );
         $this->assertEquals($expectedSchema, $schema);
     }
 

--- a/tests/PropertySchemaDecorator/AnnotationPropertySchemaDecorator/IntegerValueTest.php
+++ b/tests/PropertySchemaDecorator/AnnotationPropertySchemaDecorator/IntegerValueTest.php
@@ -13,6 +13,7 @@ class IntegerValueTestClass
 {
     /**
      * @OA\IntegerValue(minimum=10, maximum=100, multipleOf=10, exclusiveMinimum=true, exclusiveMaximum=false)
+     * @OA\Property(example="30")
      */
     public int $integer;
 
@@ -27,7 +28,7 @@ class IntegerValueTest extends AbstractAnnotationTest
     public function testIntegerAnnotation(): void
     {
         $schema = $this->getPropertySchema('integer');
-        $expectedSchema = new IntegerSchema(10, 100, true, false, 10);
+        $expectedSchema = new IntegerSchema(10, 100, true, false, 10, false, null, 30);
         $this->assertEquals($expectedSchema, $schema);
     }
 

--- a/tests/PropertySchemaDecorator/AnnotationPropertySchemaDecorator/ObjectValueTest.php
+++ b/tests/PropertySchemaDecorator/AnnotationPropertySchemaDecorator/ObjectValueTest.php
@@ -26,6 +26,14 @@ class ObjectValueTestClass
     public int $d = 10;
 }
 
+class ObjectValuePropertyTestClass
+{
+    /**
+     * @OA\Property(example="{""a"": 1, ""c"": 2, ""d"": 12}")
+     */
+    public ObjectValueTestClass $class;
+}
+
 class ObjectValueTest extends AbstractAnnotationTest
 {
     public function testRequiredProperties(): void
@@ -39,6 +47,20 @@ class ObjectValueTest extends AbstractAnnotationTest
         //    also testing that required reading from @Property work
         //    with another annotation
         $this->assertEquals(['a', 'd'], $schema->getRequiredProperties());
+    }
+
+    public function testPropertyExample(): void
+    {
+        /** @var ObjectSchema $schema */
+        $schema = $this->schemaParser->getEntitySchema(ObjectValuePropertyTestClass::class);
+        $this->assertEquals(
+            (object) [
+                'a' => 1,
+                'c' => 2,
+                'd' => 12,
+            ],
+            $schema->getPropertySchema('class')->getExample()
+        );
     }
 
     protected function createReflectionClass(): ReflectionClass

--- a/tests/PropertySchemaDecorator/AnnotationPropertySchemaDecorator/StringValueTest.php
+++ b/tests/PropertySchemaDecorator/AnnotationPropertySchemaDecorator/StringValueTest.php
@@ -17,6 +17,12 @@ class StringValueTestClass
     public string $string;
 
     /**
+     * @OA\StringValue(minLength=4, maxLength=6, pattern="[a-z0-9]+")
+     * @OA\Property(example="""test1""")
+     */
+    public string $stringExample;
+
+    /**
      * @OA\IntegerValue()
      */
     public string $incompatibleTypes;
@@ -28,6 +34,13 @@ class StringValueTest extends AbstractAnnotationTest
     {
         $schema = $this->getPropertySchema('string');
         $expectedSchema = new StringSchema(2, 10, 'email', '[a-z]+');
+        $this->assertEquals($expectedSchema, $schema);
+    }
+
+    public function testStringExampleAnnotation(): void
+    {
+        $schema = $this->getPropertySchema('stringExample');
+        $expectedSchema = new StringSchema(4, 6, null, '[a-z0-9]+', false, null, 'test1');
         $this->assertEquals($expectedSchema, $schema);
     }
 

--- a/tests/ValueSchema/Builder/ArraySchemaBuilderTest.php
+++ b/tests/ValueSchema/Builder/ArraySchemaBuilderTest.php
@@ -28,7 +28,8 @@ class ArraySchemaBuilderTest extends TestCase
         $builder = $builder->withUniqueItems(true);
         $builder = $builder->withDescription('array');
         $builder = $builder->withNullable(true);
-        $this->assertEquals(new ArraySchema(new StringSchema(), 2, 3, true, true, 'array'), $builder->build());
+        $builder = $builder->withExample([2, 3]);
+        $this->assertEquals(new ArraySchema(new StringSchema(), 2, 3, true, true, 'array', [2, 3]), $builder->build());
     }
 
     public function testMissingData(): void

--- a/tests/ValueSchema/Builder/BooleanSchemaBuilderTest.php
+++ b/tests/ValueSchema/Builder/BooleanSchemaBuilderTest.php
@@ -21,6 +21,7 @@ class BooleanSchemaBuilderTest extends TestCase
         $builder = new BooleanSchemaBuilder();
         $builder = $builder->withDescription('boolean');
         $builder = $builder->withNullable(true);
-        $this->assertEquals(new BooleanSchema(true, 'boolean'), $builder->build());
+        $builder = $builder->withExample(false);
+        $this->assertEquals(new BooleanSchema(true, 'boolean', false), $builder->build());
     }
 }

--- a/tests/ValueSchema/Builder/EnumSchemaBuilderTest.php
+++ b/tests/ValueSchema/Builder/EnumSchemaBuilderTest.php
@@ -24,7 +24,8 @@ class EnumSchemaBuilderTest extends TestCase
         $builder = $builder->withEnum(['a', 'b']);
         $builder = $builder->withDescription('enum');
         $builder = $builder->withNullable(true);
-        $this->assertEquals(new EnumSchema(['a', 'b'], true, 'enum'), $builder->build());
+        $builder = $builder->withExample('a');
+        $this->assertEquals(new EnumSchema(['a', 'b'], true, 'enum', 'a'), $builder->build());
     }
 
     public function testMissingData(): void

--- a/tests/ValueSchema/Builder/FloatSchemaBuilderTest.php
+++ b/tests/ValueSchema/Builder/FloatSchemaBuilderTest.php
@@ -26,6 +26,7 @@ class FloatSchemaBuilderTest extends TestCase
         $builder = $builder->withMultipleOf(0.1);
         $builder = $builder->withDescription('float');
         $builder = $builder->withNullable(true);
-        $this->assertEquals(new FloatSchema(1.1, 2.2, true, false, 0.1, true, 'float'), $builder->build());
+        $builder = $builder->withExample(1.2);
+        $this->assertEquals(new FloatSchema(1.1, 2.2, true, false, 0.1, true, 'float', 1.2), $builder->build());
     }
 }

--- a/tests/ValueSchema/Builder/HashmapSchemaBuilderTest.php
+++ b/tests/ValueSchema/Builder/HashmapSchemaBuilderTest.php
@@ -26,8 +26,15 @@ class HashmapSchemaBuilderTest extends TestCase
         $builder = $builder->withRequiredProperties(['property']);
         $builder = $builder->withDescription('hashmap');
         $builder = $builder->withNullable(true);
+        $builder = $builder->withExample((object) [
+            'property' => 'x',
+            'a' => 'b',
+        ]);
         $this->assertEquals(
-            new HashmapSchema(new StringSchema(), ['property'], true, 'hashmap'),
+            new HashmapSchema(new StringSchema(), ['property'], true, 'hashmap', (object) [
+                'property' => 'x',
+                'a' => 'b',
+            ]),
             $builder->build()
         );
     }

--- a/tests/ValueSchema/Builder/IntegerSchemaBuilderTest.php
+++ b/tests/ValueSchema/Builder/IntegerSchemaBuilderTest.php
@@ -26,6 +26,7 @@ class IntegerSchemaBuilderTest extends TestCase
         $builder = $builder->withMultipleOf(2);
         $builder = $builder->withDescription('integer');
         $builder = $builder->withNullable(true);
-        $this->assertEquals(new IntegerSchema(0, 10, true, false, 2, true, 'integer'), $builder->build());
+        $builder = $builder->withExample(4);
+        $this->assertEquals(new IntegerSchema(0, 10, true, false, 2, true, 'integer', 4), $builder->build());
     }
 }

--- a/tests/ValueSchema/Builder/MixedSchemaBuilderTest.php
+++ b/tests/ValueSchema/Builder/MixedSchemaBuilderTest.php
@@ -21,6 +21,7 @@ class MixedSchemaBuilderTest extends TestCase
         $builder = new MixedSchemaBuilder();
         $builder = $builder->withDescription('boolean');
         $builder = $builder->withNullable(true);
-        $this->assertEquals(new MixedSchema(true, 'boolean'), $builder->build());
+        $builder = $builder->withExample(true);
+        $this->assertEquals(new MixedSchema(true, 'boolean', true), $builder->build());
     }
 }

--- a/tests/ValueSchema/Builder/ObjectSchemaBuilderTest.php
+++ b/tests/ValueSchema/Builder/ObjectSchemaBuilderTest.php
@@ -26,10 +26,17 @@ class ObjectSchemaBuilderTest extends TestCase
         $builder = $builder->withRequiredProperties(['property']);
         $builder = $builder->withDescription('object');
         $builder = $builder->withNullable(true);
+        $builder = $builder->withExample((object) [
+            'property' => 'test',
+            'c' => 'd',
+        ]);
         $this->assertEquals(
             new ObjectSchema([
                 'property' => new StringSchema(),
-            ], ['property'], true, 'object'),
+            ], ['property'], true, 'object', (object) [
+                'property' => 'test',
+                'c' => 'd',
+            ]),
             $builder->build()
         );
     }

--- a/tests/ValueSchema/Builder/StringSchemaBuilderTest.php
+++ b/tests/ValueSchema/Builder/StringSchemaBuilderTest.php
@@ -25,6 +25,10 @@ class StringSchemaBuilderTest extends TestCase
         $builder = $builder->withPattern('[a-z]+');
         $builder = $builder->withDescription('string');
         $builder = $builder->withNullable(true);
-        $this->assertEquals(new StringSchema(10, 12, 'email', '[a-z]+', true, 'string'), $builder->build());
+        $builder = $builder->withExample('someemail');
+        $this->assertEquals(
+            new StringSchema(10, 12, 'email', '[a-z]+', true, 'string', 'someemail'),
+            $builder->build()
+        );
     }
 }


### PR DESCRIPTION
#### What's this PR do?

- Solving issue #7 
- Add support for `example` in `OA\Property`
- Do validity checking for example by schema

#### Recommendation for how to test this, or anything you are worried about?

- OpenAPI schema also support `examples` (https://swagger.io/docs/specification/adding-examples/)
- SchemaValues doesn't check example schema validity by itself (it's dumb value object...)
- Schema validity check is now do in `AnnotationPropertySchemaDecorator`, but maybe this can be done in SchemaParser before `build()` is called - but this still not solving previous problem - any suggestions?