### PR TITLE
StringValidator: fix min/max length - edge values can be equal

### DIFF
--- a/src/Validation/Validator/StringValidator.php
+++ b/src/Validation/Validator/StringValidator.php
@@ -42,10 +42,10 @@ final class StringValidator extends AbstractValidator
 
         $strlen = $this->schema->getFormat() === 'binary' ? \strlen($data) : \mb_strlen($data);
 
-        if (($minLength = $this->schema->getMinLength()) !== null && $minLength >= $strlen) {
+        if (($minLength = $this->schema->getMinLength()) !== null && $minLength > $strlen) {
             $resultBuilder->addMinLengthViolation($minLength, $breadCrumbPath);
         }
-        if (($maxLength = $this->schema->getMaxLength()) !== null && $maxLength <= $strlen) {
+        if (($maxLength = $this->schema->getMaxLength()) !== null && $maxLength < $strlen) {
             $resultBuilder->addMaxLengthViolation($maxLength, $breadCrumbPath);
         }
         if (($pattern = $this->schema->getPattern()) !== null) {

--- a/tests/Validation/ValueValidatorValidateTest.php
+++ b/tests/Validation/ValueValidatorValidateTest.php
@@ -270,7 +270,9 @@ class ValueValidatorValidateTest extends TestCase
             // string
             'string:valid' => [new StringSchema(), 'hello', []],
             'string:valid-null' => [new StringSchema(null, null, null, null, true), null, []],
+            'string:valid-minLength-equal' => [new StringSchema(1), 'a', []],
             'string:valid-minLength' => [new StringSchema(1), 'aa', []],
+            'string:valid-maxLength-equal' => [new StringSchema(null, 3), 'aaa', []],
             'string:valid-maxLength' => [new StringSchema(null, 3), 'aa', []],
             'string:valid-format' => [
                 new StringSchema(null, null, 'date-time'),


### PR DESCRIPTION
#### What's this PR do?

Fix string length validation. Equality is also allowed.

#### Any background context you want to provide?

https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.7