### PR TITLE
StringValidator: fix format substring match

### DIFF
--- a/src/Validation/Validator/StringValidator.php
+++ b/src/Validation/Validator/StringValidator.php
@@ -88,8 +88,8 @@ final class StringValidator extends AbstractValidator
         switch ($format) {
             case 'password':
             case 'binary': return '~.*~';
-            case 'date': return '~[0-9]{4}-[0-9]{2}-[0-9]{2}~';
-            case 'date-time': return '~[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+(Z|([+-][0-9]{2}:[0-9]{2})))?~';
+            case 'date': return '~^[0-9]{4}-[0-9]{2}-[0-9]{2}$~';
+            case 'date-time': return '~^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+(Z|([+-][0-9]{2}:[0-9]{2})))?$~';
 
             case 'byte':
                 throw new RuntimeException("Not implemented format '${format}'.");

--- a/tests/Validation/ValueValidatorValidateTest.php
+++ b/tests/Validation/ValueValidatorValidateTest.php
@@ -295,6 +295,11 @@ class ValueValidatorValidateTest extends TestCase
                 '2020-12-30',
                 [[1016, "Value doesn't have format '%s'.", ['date-time'], '']],
             ],
+            'string:format-regression-missing-plus' => [
+                new StringSchema(null, null, 'date-time'),
+                '2020-12-30T23:22:21 01:00',
+                [[1016, "Value doesn't have format '%s'.", ['date-time'], '']],
+            ],
             'string:pattern' => [
                 new StringSchema(null, null, null, '-[0-9]{3}'),
                 '2020-12-30',


### PR DESCRIPTION
#### What's this PR do?

Fixes string validator tolerance to prefix or suffix of valid date and date-time formats.