### PR TITLE
Bump Symplify 10 and PHPStan 1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,27 +1,23 @@
 name: build
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+    push: null
+    pull_request:
+        branches:
+          -  master
 
 jobs:
-  build:
+    build:
+        runs-on: ubuntu-latest
 
-    runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
 
-    steps:
-    - uses: actions/checkout@v2
+            - name: Validate composer.json and composer.lock
+              run: composer validate
 
-    - name: Validate composer.json and composer.lock
-      run: composer validate
+            - name: Install dependencies
+              uses: "ramsey/composer-install@v1"
 
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-suggest
-
-    # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
-    # Docs: https://getcomposer.org/doc/articles/scripts.md
-
-    - name: Run test suite
-      run: composer run-script test
+            - name: Run test suite
+              run: vendor/bin/phpunit

--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -1,0 +1,36 @@
+name: Code Analysys
+
+on:
+    push: null
+    pull_request:
+        branches:
+            - master
+
+jobs:
+    code_analysis:
+        strategy:
+            fail-fast: false
+            matrix:
+                actions:
+                    -
+                        name: 'PHPStan'
+                        run: composer phpstan
+
+                    -
+                        name: 'Coding Standard'
+                        run: composer check-cs
+
+                    -
+                        name: 'Lint PHP Code'
+                        run: vendor/bin/parallel-lint src tests
+
+        name: ${{ matrix.actions.name }}
+
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+
+            - uses: "ramsey/composer-install@v1"
+
+            - run: ${{ matrix.actions.run }}

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "doctrine/annotations": "^1.11",
+        "doctrine/annotations": "^1.13",
         "ext-json": "*",
         "nette/di": "^3.0",
         "nette/utils": "^3.1",
@@ -19,27 +19,24 @@
         "scrumworks/property-reader": "^0.3.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.4.2",
+        "phpunit/phpunit": "^9.5",
         "php-parallel-lint/php-parallel-lint": "^1.2",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan": "^0.12.48",
-        "phpstan/phpstan-nette": "^0.12.0",
-        "symplify/easy-coding-standard": "^8.3",
-        "symplify/easy-testing": "^8.3",
-        "migrify/template-checker": "^0.3.49",
-        "symplify/phpstan-extensions": "^8.3",
-        "slevomat/coding-standard": "^6.4"
+        "phpstan/phpstan": "^1.0",
+        "phpstan/phpstan-nette": "^1.0",
+        "symplify/easy-coding-standard": "^10.0",
+        "symplify/easy-testing": "^10.0",
+        "symplify/easy-ci": "^10.0",
+        "symplify/phpstan-extensions": "^10.0"
     },
     "autoload": {
         "psr-4": {
-            "ScrumWorks\\OpenApiSchema\\": [
-                "src"
-            ]
+            "ScrumWorks\\OpenApiSchema\\": "src"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "ScrumWorks\\OpenApiSchema\\Tests\\": "tests/"
+            "ScrumWorks\\OpenApiSchema\\Tests\\": "tests"
         }
     },
     "scripts": {
@@ -49,5 +46,7 @@
         "phpstan" : "php -d memory_limit=2048M vendor/bin/phpstan.phar analyse --ansi --error-format symplify",
         "phpunit": "php vendor/bin/phpunit -c ./phpunit.xml",
         "test": ["@lint", "@check-cs", "@phpstan", "@phpunit"]
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-nette": "^1.0",
+        "slevomat/coding-standard": "^7.1",
         "symplify/easy-coding-standard": "^10.0",
         "symplify/easy-testing": "^10.0",
         "symplify/easy-ci": "^10.0",

--- a/ecs.php
+++ b/ecs.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use PhpCsFixer\Fixer\Basic\Psr4Fixer;
+//use PhpCsFixer\Fixer\Basic\Psr4Fixer;
 use PhpCsFixer\Fixer\Casing\NativeFunctionCasingFixer;
 use PhpCsFixer\Fixer\FunctionNotation\NativeFunctionInvocationFixer;
 use PhpCsFixer\Fixer\Import\FullyQualifiedStrictTypesFixer;
@@ -15,78 +15,76 @@ use PhpCsFixer\Fixer\Strict\StrictComparisonFixer;
 use PhpCsFixer\Fixer\Strict\StrictParamFixer;
 use PhpCsFixer\Fixer\Whitespace\IndentationTypeFixer;
 use PhpCsFixer\Fixer\Whitespace\MethodChainingIndentationFixer;
-use SlevomatCodingStandard\Helpers\PropertyTypeHint;
 use SlevomatCodingStandard\Sniffs\Arrays\DisallowImplicitArrayCreationSniff;
 use SlevomatCodingStandard\Sniffs\Classes\DisallowLateStaticBindingForConstantsSniff;
-use SlevomatCodingStandard\Sniffs\Classes\UnusedPrivateElementsSniff;
 use SlevomatCodingStandard\Sniffs\Classes\UselessLateStaticBindingSniff;
 use SlevomatCodingStandard\Sniffs\ControlStructures\RequireNullCoalesceOperatorSniff;
 use SlevomatCodingStandard\Sniffs\Exceptions\DeadCatchSniff;
-use SlevomatCodingStandard\Sniffs\Exceptions\ReferenceThrowableOnlySniff;
 use SlevomatCodingStandard\Sniffs\Functions\StaticClosureSniff;
-use SlevomatCodingStandard\Sniffs\Namespaces\ReferenceUsedNamesOnlySniff;
-use SlevomatCodingStandard\Sniffs\Namespaces\UnusedUsesSniff;
 use SlevomatCodingStandard\Sniffs\Namespaces\UseFromSameNamespaceSniff;
 use SlevomatCodingStandard\Sniffs\PHP\OptimizedFunctionsWithoutUnpackingSniff;
 use SlevomatCodingStandard\Sniffs\PHP\UselessParenthesesSniff;
 use SlevomatCodingStandard\Sniffs\PHP\UselessSemicolonSniff;
-use SlevomatCodingStandard\Sniffs\TypeHints\PropertyTypeHintSniff;
 use SlevomatCodingStandard\Sniffs\Variables\DuplicateAssignmentToVariableSniff;
-use SlevomatCodingStandard\Sniffs\Variables\UnusedVariableSniff;
 use SlevomatCodingStandard\Sniffs\Variables\UselessVariableSniff;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\CodingStandard\Fixer\ArrayNotation\StandaloneLineInMultilineArrayFixer;
 use Symplify\CodingStandard\Fixer\Commenting\ParamReturnAndVarTagMalformsFixer;
 use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
-use Symplify\CodingStandard\Fixer\Spacing\RemoveSpacingAroundModifierAndConstFixer;
+use Symplify\EasyCodingStandard\ValueObject\Option;
 use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 
 # see https://github.com/symplify/easy-coding-standard
 return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
 
-    $parameters->set('paths', [
+    $parameters->set(Option::PARALLEL, true);
+
+    $parameters->set(Option::PATHS, [
         __DIR__ . '/src',
         __DIR__ . '/tests',
     ]);
 
-    $parameters->set('sets', [
-        # pick anything from https://github.com/symplify/easy-coding-standard#use-prepared-checker-sets
-        SetList::PSR_12,
-        SetList::COMMON,
-        SetList::PHP_70,
-        SetList::PHP_71,
-        SetList::CLEAN_CODE,
-        SetList::DEAD_CODE,
-    ]);
+    // pick anything from https://github.com/symplify/easy-coding-standard#use-prepared-checker-sets
+    $containerConfigurator->import(SetList::PSR_12);
+    $containerConfigurator->import(SetList::COMMON);
+    $containerConfigurator->import(SetList::CLEAN_CODE);
 
-    $parameters->set('skip', [
-        ReferenceUsedNamesOnlySniff::class . '.' . ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME_WITHOUT_NAMESPACE => null,
-        ReferenceUsedNamesOnlySniff::class . '.' . ReferenceUsedNamesOnlySniff::CODE_PARTIAL_USE => null,
+    $parameters->set(Option::SKIP, [
+        __DIR__ . '/src/SchemaBuilder/Decorator/PropertyDecorator/AnnotationPropertySchemaDecorator.php',
+        __DIR__ . '/src/Validation/Validator/UnionValidator.php',
 
-        // we can't use FQN in doctrine annotations
-        ReferenceUsedNamesOnlySniff::class . '.' . ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME => [
-            __DIR__ . '/src/Annotation/ArrayValue.php',
-            __DIR__ . '/src/Annotation/HashmapValue.php',
-            __DIR__ . '/src/Annotation/Union.php',
+//        ReferenceUsedNamesOnlySniff::class . '.' . ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME_WITHOUT_NAMESPACE => null,
+//        ReferenceUsedNamesOnlySniff::class . '.' . ReferenceUsedNamesOnlySniff::CODE_PARTIAL_USE => null,
+//
+//        // we can't use FQN in doctrine annotations
+//        ReferenceUsedNamesOnlySniff::class . '.' . ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME => [
+//            __DIR__ . '/src/Annotation/ArrayValue.php',
+//            __DIR__ . '/src/Annotation/HashmapValue.php',
+//            __DIR__ . '/src/Annotation/Union.php',
+//        ],
+//        UseFromSameNamespaceSniff::class . '.' . UseFromSameNamespaceSniff::CODE_USE_FROM_SAME_NAMESPACE => [
+//            __DIR__ . '/src/Annotation/ArrayValue.php',
+//            __DIR__ . '/src/Annotation/HashmapValue.php',
+//            __DIR__ . '/src/Annotation/Union.php',
+//        ],
+//
+//        # resolve later with strict_types
+//        DeclareStrictTypesFixer::class => null,
+//        StrictComparisonFixer::class => null,
+        PhpUnitStrictFixer::class => [
+            // compare 2 object contents
+            __DIR__ . '/tests/ValueSchema/Builder',
+            __DIR__ . '/tests/SchemaParserTest.php',
+            __DIR__ . '/tests/OpenApiTranslatorTest.php',
         ],
-        UseFromSameNamespaceSniff::class . '.' . UseFromSameNamespaceSniff::CODE_USE_FROM_SAME_NAMESPACE => [
-            __DIR__ . '/src/Annotation/ArrayValue.php',
-            __DIR__ . '/src/Annotation/HashmapValue.php',
-            __DIR__ . '/src/Annotation/Union.php',
-        ],
-
-        # resolve later with strict_types
-        DeclareStrictTypesFixer::class => null,
-        StrictComparisonFixer::class => null,
-        PhpUnitStrictFixer::class => null,
-        StrictParamFixer::class => null,
-        # breaks code
-        ReferenceThrowableOnlySniff::class . '.' . ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION => null,
-        Psr4Fixer::class => null,
-        UnusedUsesSniff::class . '.' . UnusedUsesSniff::CODE_MISMATCHING_CASE => [
-            __DIR__ . '/tests/*',
-        ],
+//        StrictParamFixer::class => null,
+//        # breaks code
+//        ReferenceThrowableOnlySniff::class . '.' . ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION => null,
+//        Psr4Fixer::class => null,
+//        UnusedUsesSniff::class . '.' . UnusedUsesSniff::CODE_MISMATCHING_CASE => [
+//            __DIR__ . '/tests/*',
+//        ],
     ]);
 
     $services = $containerConfigurator->services();
@@ -108,11 +106,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(LineLengthFixer::class);
 
     # imports FQN names
-    $services->set(ReferenceUsedNamesOnlySniff::class)
-        ->property('searchAnnotations', true)
-        ->property('allowFullyQualifiedGlobalFunctions', true)
-        ->property('allowFullyQualifiedGlobalConstants', true)
-        ->property('allowPartialUses', false);
+//    $services->set(ReferenceUsedNamesOnlySniff::class)
+//        ->property('searchAnnotations', true)
+//        ->property('allowFullyQualifiedGlobalFunctions', true)
+//        ->property('allowFullyQualifiedGlobalConstants', true)
+//        ->property('allowPartialUses', false);
 
     # make @var annotation into doc block
     $services->set(PhpdocLineSpanFixer::class);
@@ -126,7 +124,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(ParamReturnAndVarTagMalformsFixer::class);
 
     # spaces
-    $services->set(RemoveSpacingAroundModifierAndConstFixer::class);
+    // $services->set(RemoveSpacingAroundModifierAndConstFixer::class);
 
     # use 4 spaces to indent
     $services->set(IndentationTypeFixer::class);

--- a/ecs.php
+++ b/ecs.php
@@ -2,17 +2,14 @@
 
 declare(strict_types=1);
 
-//use PhpCsFixer\Fixer\Basic\Psr4Fixer;
 use PhpCsFixer\Fixer\Casing\NativeFunctionCasingFixer;
+use PhpCsFixer\Fixer\ClassNotation\ProtectedToPrivateFixer;
 use PhpCsFixer\Fixer\FunctionNotation\NativeFunctionInvocationFixer;
 use PhpCsFixer\Fixer\Import\FullyQualifiedStrictTypesFixer;
 use PhpCsFixer\Fixer\Import\GlobalNamespaceImportFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitStrictFixer;
 use PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocLineSpanFixer;
-use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
-use PhpCsFixer\Fixer\Strict\StrictComparisonFixer;
-use PhpCsFixer\Fixer\Strict\StrictParamFixer;
 use PhpCsFixer\Fixer\Whitespace\IndentationTypeFixer;
 use PhpCsFixer\Fixer\Whitespace\MethodChainingIndentationFixer;
 use SlevomatCodingStandard\Sniffs\Arrays\DisallowImplicitArrayCreationSniff;
@@ -21,6 +18,7 @@ use SlevomatCodingStandard\Sniffs\Classes\UselessLateStaticBindingSniff;
 use SlevomatCodingStandard\Sniffs\ControlStructures\RequireNullCoalesceOperatorSniff;
 use SlevomatCodingStandard\Sniffs\Exceptions\DeadCatchSniff;
 use SlevomatCodingStandard\Sniffs\Functions\StaticClosureSniff;
+use SlevomatCodingStandard\Sniffs\Namespaces\ReferenceUsedNamesOnlySniff;
 use SlevomatCodingStandard\Sniffs\Namespaces\UseFromSameNamespaceSniff;
 use SlevomatCodingStandard\Sniffs\PHP\OptimizedFunctionsWithoutUnpackingSniff;
 use SlevomatCodingStandard\Sniffs\PHP\UselessParenthesesSniff;
@@ -51,47 +49,28 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->import(SetList::CLEAN_CODE);
 
     $parameters->set(Option::SKIP, [
-        __DIR__ . '/src/SchemaBuilder/Decorator/PropertyDecorator/AnnotationPropertySchemaDecorator.php',
-        __DIR__ . '/src/Validation/Validator/UnionValidator.php',
+        // allowed
+        \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\AssignmentInConditionSniff::class . '.FoundInWhileCondition',
 
-//        ReferenceUsedNamesOnlySniff::class . '.' . ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME_WITHOUT_NAMESPACE => null,
-//        ReferenceUsedNamesOnlySniff::class . '.' . ReferenceUsedNamesOnlySniff::CODE_PARTIAL_USE => null,
-//
-//        // we can't use FQN in doctrine annotations
-//        ReferenceUsedNamesOnlySniff::class . '.' . ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME => [
-//            __DIR__ . '/src/Annotation/ArrayValue.php',
-//            __DIR__ . '/src/Annotation/HashmapValue.php',
-//            __DIR__ . '/src/Annotation/Union.php',
-//        ],
-//        UseFromSameNamespaceSniff::class . '.' . UseFromSameNamespaceSniff::CODE_USE_FROM_SAME_NAMESPACE => [
-//            __DIR__ . '/src/Annotation/ArrayValue.php',
-//            __DIR__ . '/src/Annotation/HashmapValue.php',
-//            __DIR__ . '/src/Annotation/Union.php',
-//        ],
-//
-//        # resolve later with strict_types
-//        DeclareStrictTypesFixer::class => null,
-//        StrictComparisonFixer::class => null,
+        // we can't use FQN in doctrine annotations
+        ReferenceUsedNamesOnlySniff::class . '.' . ReferenceUsedNamesOnlySniff::CODE_REFERENCE_VIA_FULLY_QUALIFIED_NAME => [
+            __DIR__ . '/src/Annotation/ArrayValue.php',
+            __DIR__ . '/src/Annotation/HashmapValue.php',
+            __DIR__ . '/src/Annotation/Union.php',
+            __DIR__ . '/src/Annotation/HashmapValue.php',
+        ],
+
+        // compare 2 object contents
         PhpUnitStrictFixer::class => [
-            // compare 2 object contents
             __DIR__ . '/tests/ValueSchema/Builder',
             __DIR__ . '/tests/SchemaParserTest.php',
             __DIR__ . '/tests/OpenApiTranslatorTest.php',
         ],
-//        StrictParamFixer::class => null,
-//        # breaks code
-//        ReferenceThrowableOnlySniff::class . '.' . ReferenceThrowableOnlySniff::CODE_REFERENCED_GENERAL_EXCEPTION => null,
-//        Psr4Fixer::class => null,
-//        UnusedUsesSniff::class . '.' . UnusedUsesSniff::CODE_MISMATCHING_CASE => [
-//            __DIR__ . '/tests/*',
-//        ],
     ]);
 
     $services = $containerConfigurator->services();
 
-    // @todo fix
-    // $services->set(ProtectedToPrivateFixer::class);
-
+    $services->set(ProtectedToPrivateFixer::class);
     $services->set(MethodChainingIndentationFixer::class);
 
     $services->set(GeneralPhpdocAnnotationRemoveFixer::class)
@@ -106,11 +85,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(LineLengthFixer::class);
 
     # imports FQN names
-//    $services->set(ReferenceUsedNamesOnlySniff::class)
-//        ->property('searchAnnotations', true)
-//        ->property('allowFullyQualifiedGlobalFunctions', true)
-//        ->property('allowFullyQualifiedGlobalConstants', true)
-//        ->property('allowPartialUses', false);
+    $services->set(ReferenceUsedNamesOnlySniff::class)
+        ->property('searchAnnotations', true)
+        ->property('allowFullyQualifiedGlobalFunctions', true)
+        ->property('allowFullyQualifiedGlobalConstants', true)
+        ->property('allowPartialUses', false);
 
     # make @var annotation into doc block
     $services->set(PhpdocLineSpanFixer::class);
@@ -123,9 +102,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     # make @param, @return and @var format united
     $services->set(ParamReturnAndVarTagMalformsFixer::class);
 
-    # spaces
-    // $services->set(RemoveSpacingAroundModifierAndConstFixer::class);
-
     # use 4 spaces to indent
     $services->set(IndentationTypeFixer::class);
 
@@ -134,31 +110,19 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     # import namespaces
     $services->set(FullyQualifiedStrictTypesFixer::class);
-
     $services->set(GlobalNamespaceImportFixer::class);
 
-    # slevomat rules from ruleset.xml
+    // slevomat rules
     $services->set(UseFromSameNamespaceSniff::class);
-
     $services->set(DuplicateAssignmentToVariableSniff::class);
-
     $services->set(OptimizedFunctionsWithoutUnpackingSniff::class);
-
     $services->set(UselessSemicolonSniff::class);
-
     $services->set(DeadCatchSniff::class);
-
     $services->set(UselessVariableSniff::class);
-
     $services->set(UselessParenthesesSniff::class);
-
     $services->set(DisallowLateStaticBindingForConstantsSniff::class);
-
     $services->set(UselessLateStaticBindingSniff::class);
-
     $services->set(RequireNullCoalesceOperatorSniff::class);
-
     $services->set(StaticClosureSniff::class);
-
     $services->set(DisallowImplicitArrayCreationSniff::class);
 };

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -18,5 +18,8 @@ parameters:
     parallel:
         processTimeout: 300.0
 
-includes:
-    - vendor/symplify/phpstan-extensions/config/config.neon
+    ignoreErrors:
+        # Closure vs callable mix
+        - '#Parameter \#1 \$callback of function array_map expects \(callable\(ScrumWorks\\OpenApiSchema\\Validation\\ValidityViolationInterface\)\: mixed\)\|null, Closure\(ScrumWorks\\OpenApiSchema\\Validation\\Result\\ValidityViolation\)\: string given#'
+        - '#Parameter \#1 \$callback of function array_map expects \(callable\(ScrumWorks\\OpenApiSchema\\Validation\\ValidityViolationInterface\)\: mixed\)\|null, Closure\(ScrumWorks\\OpenApiSchema\\Validation\\Result\\ValidityViolation\)\: string given#'
+

--- a/src/Annotation/ArrayValue.php
+++ b/src/Annotation/ArrayValue.php
@@ -28,7 +28,6 @@ final class ArrayValue implements ValueInterface
     public ?bool $uniqueItems = null;
 
     /**
-     * @codingStandardsIgnoreLine
      * @var \ScrumWorks\OpenApiSchema\Annotation\ValueInterface we can't FQN, because shitty doctrine annotations
      */
     public ?ValueInterface $itemsSchema = null;

--- a/src/Annotation/HashmapValue.php
+++ b/src/Annotation/HashmapValue.php
@@ -18,7 +18,6 @@ final class HashmapValue implements ValueInterface
     public array $requiredProperties = [];
 
     /**
-     * @codingStandardsIgnoreLine
      * @var \ScrumWorks\OpenApiSchema\Annotation\ValueInterface we can't FQN, because shitty doctrine annotations
      */
     public ?ValueInterface $itemsSchema = null;

--- a/src/DI/DiContainerFactory.php
+++ b/src/DI/DiContainerFactory.php
@@ -16,7 +16,7 @@ class DiContainerFactory
 
     public function __construct(?string $tempDir = null, bool $autoRebuild = false)
     {
-        $this->tempDir = $tempDir ?? \sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ScrumWorksOpenApiSchema';
+        $this->tempDir = $tempDir ?? sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ScrumWorksOpenApiSchema';
         $this->autoRebuild = $autoRebuild;
     }
 

--- a/src/DI/OpenApiSchemaExtension.php
+++ b/src/DI/OpenApiSchemaExtension.php
@@ -64,7 +64,7 @@ class OpenApiSchemaExtension extends CompilerExtension
         $factory = $def->getFactory();
 
         for ($i = 0; $i < \count($factory->arguments); ++$i) {
-            \usort($factory->arguments[$i], function (Reference $a, Reference $b) {
+            usort($factory->arguments[$i], function (Reference $a, Reference $b) {
                 return $this->getServicePriority($a->getValue()) <=> $this->getServicePriority($b->getValue());
             });
         }

--- a/src/OpenApiTranslator.php
+++ b/src/OpenApiTranslator.php
@@ -140,7 +140,7 @@ class OpenApiTranslator implements OpenApiTranslatorInterface
         ];
         if ($schema->getPropertiesSchemas()) {
             // we use property of `array_map` function that preserve keys
-            $definition['properties'] = \array_map(
+            $definition['properties'] = array_map(
                 fn (ValueSchemaInterface $property) => $this->translateValueSchema($property),
                 $schema->getPropertiesSchemas()
             );

--- a/src/SchemaBuilder/Decorator/AbstractAnnotationSchemaDecorator.php
+++ b/src/SchemaBuilder/Decorator/AbstractAnnotationSchemaDecorator.php
@@ -29,6 +29,11 @@ abstract class AbstractAnnotationSchemaDecorator
         return $this->annotationReader->getClassAnnotations($classReflection);
     }
 
+    /**
+     * @template T as object
+     * @param class-string<T> $annotationClass
+     * @return T|null
+     */
     protected function findAnnotation(
         array $annotations,
         string $annotationClass,
@@ -45,9 +50,9 @@ abstract class AbstractAnnotationSchemaDecorator
                 $found = $annotation;
             } elseif (
                 $exceptionOnAnotherValueInterface
-                && \is_subclass_of($annotation, OA\ValueInterface::class)
+                && is_subclass_of($annotation, OA\ValueInterface::class)
             ) {
-                throw new LogicException(\sprintf("Unexpected annotation '%s'", \get_class($annotation)));
+                throw new LogicException(sprintf("Unexpected annotation '%s'", \get_class($annotation)));
             }
         }
 

--- a/src/SchemaBuilder/Decorator/AbstractAnnotationSchemaDecorator.php
+++ b/src/SchemaBuilder/Decorator/AbstractAnnotationSchemaDecorator.php
@@ -7,7 +7,7 @@ namespace ScrumWorks\OpenApiSchema\SchemaBuilder\Decorator;
 use Doctrine\Common\Annotations\Reader;
 use ReflectionClass;
 use ReflectionProperty;
-use ScrumWorks\OpenApiSchema\Annotation as OA;
+use ScrumWorks\OpenApiSchema\Annotation\ValueInterface;
 use ScrumWorks\OpenApiSchema\Exception\LogicException;
 
 abstract class AbstractAnnotationSchemaDecorator
@@ -50,7 +50,7 @@ abstract class AbstractAnnotationSchemaDecorator
                 $found = $annotation;
             } elseif (
                 $exceptionOnAnotherValueInterface
-                && is_subclass_of($annotation, OA\ValueInterface::class)
+                && is_subclass_of($annotation, ValueInterface::class)
             ) {
                 throw new LogicException(sprintf("Unexpected annotation '%s'", \get_class($annotation)));
             }

--- a/src/SchemaBuilder/Decorator/ClassDecorator/AnnotationClassSchemaDecorator.php
+++ b/src/SchemaBuilder/Decorator/ClassDecorator/AnnotationClassSchemaDecorator.php
@@ -6,7 +6,8 @@ namespace ScrumWorks\OpenApiSchema\SchemaBuilder\Decorator\ClassDecorator;
 
 use ReflectionClass;
 use ReflectionProperty;
-use ScrumWorks\OpenApiSchema\Annotation as OA;
+use ScrumWorks\OpenApiSchema\Annotation\ComponentSchema;
+use ScrumWorks\OpenApiSchema\Annotation\Property;
 use ScrumWorks\OpenApiSchema\SchemaBuilder\Decorator\AbstractAnnotationSchemaDecorator;
 use ScrumWorks\OpenApiSchema\SchemaBuilder\Decorator\ClassSchemaDecoratorInterface;
 use ScrumWorks\OpenApiSchema\ValueSchema\Builder\AbstractSchemaBuilder;
@@ -34,9 +35,9 @@ final class AnnotationClassSchemaDecorator extends AbstractAnnotationSchemaDecor
         }
 
         $classAnnotations = $this->getClassAnnotations($classReflection);
-        /** @var ?OA\ComponentSchema $componentSchema */
-        $componentSchema = $this->findAnnotation($classAnnotations, OA\ComponentSchema::class, true);
-        if ($componentSchema && $componentSchema->schemaName) {
+
+        $componentSchema = $this->findAnnotation($classAnnotations, ComponentSchema::class, true);
+        if ($componentSchema instanceof ComponentSchema && $componentSchema->schemaName) {
             $builder = $builder->withSchemaName($componentSchema->schemaName);
         }
 
@@ -46,9 +47,9 @@ final class AnnotationClassSchemaDecorator extends AbstractAnnotationSchemaDecor
     private function isPropertyRequired(ReflectionProperty $propertyReflection, array $objectDefaultValues): bool
     {
         $annotations = $this->getPropertyAnnotations($propertyReflection);
-        /** @var ?OA\Property $annotation */
-        $annotation = $this->findAnnotation($annotations, OA\Property::class, false);
-        if ($annotation && $annotation->required !== null) {
+
+        $annotation = $this->findAnnotation($annotations, Property::class, false);
+        if ($annotation instanceof Property && $annotation->required !== null) {
             return $annotation->required;
         }
         return ! \array_key_exists($propertyReflection->getName(), $objectDefaultValues);

--- a/src/SchemaBuilder/Decorator/ClassDecorator/BasicClassSchemaDecorator.php
+++ b/src/SchemaBuilder/Decorator/ClassDecorator/BasicClassSchemaDecorator.php
@@ -21,7 +21,7 @@ final class BasicClassSchemaDecorator implements ClassSchemaDecoratorInterface
 
         $objectDefaultValues = $classReflexion->getDefaultProperties();
         $requiredProperties = [];
-        foreach (\array_keys($builder->getPropertiesSchemaBuilders()) as $propertyName) {
+        foreach (array_keys($builder->getPropertiesSchemaBuilders()) as $propertyName) {
             if (! \array_key_exists($propertyName, $objectDefaultValues)) {
                 $requiredProperties[] = $propertyName;
             }

--- a/src/SchemaBuilder/Decorator/ClassDecorator/DateTimeClassSchemaDecorator.php
+++ b/src/SchemaBuilder/Decorator/ClassDecorator/DateTimeClassSchemaDecorator.php
@@ -16,7 +16,7 @@ final class DateTimeClassSchemaDecorator implements ClassSchemaDecoratorInterfac
         AbstractSchemaBuilder $builder,
         ReflectionClass $classReflection
     ): AbstractSchemaBuilder {
-        if (\is_a($classReflection->getName(), DateTimeInterface::class, true)) {
+        if (is_a($classReflection->getName(), DateTimeInterface::class, true)) {
             return (new StringSchemaBuilder())
                 ->withNullable($builder->isNullable())
                 ->withSchemaName($builder->getSchemaName())

--- a/src/SchemaBuilder/Decorator/PropertyDecorator/AnnotationPropertySchemaDecorator.php
+++ b/src/SchemaBuilder/Decorator/PropertyDecorator/AnnotationPropertySchemaDecorator.php
@@ -68,8 +68,9 @@ final class AnnotationPropertySchemaDecorator extends AbstractAnnotationSchemaDe
         AbstractSchemaBuilder $builder,
         array $annotations
     ): AbstractSchemaBuilder {
-        if ($annotation = $this->findAnnotation($annotations, OA\Property ::class, false)) {
-            /** @var OA\Property $annotation */
+        $annotation = $this->findAnnotation($annotations, OA\Property ::class, false);
+
+        if ($annotation instanceof OA\Property) {
             if ($annotation->description !== null) {
                 $builder = $builder->withDescription($annotation->description);
             }
@@ -86,8 +87,8 @@ final class AnnotationPropertySchemaDecorator extends AbstractAnnotationSchemaDe
         IntegerSchemaBuilder $builder,
         array $annotations
     ): AbstractSchemaBuilder {
-        if ($annotation = $this->findAnnotation($annotations, OA\IntegerValue::class)) {
-            /** @var OA\IntegerValue $annotation */
+        $annotation = $this->findAnnotation($annotations, OA\IntegerValue::class);
+        if ($annotation instanceof OA\IntegerValue) {
             if ($annotation->minimum !== null) {
                 $builder = $builder->withMinimum($annotation->minimum);
             }
@@ -112,8 +113,9 @@ final class AnnotationPropertySchemaDecorator extends AbstractAnnotationSchemaDe
         FloatSchemaBuilder $builder,
         array $annotations
     ): AbstractSchemaBuilder {
-        if ($annotation = $this->findAnnotation($annotations, OA\FloatValue::class)) {
-            /** @var OA\FloatValue $annotation */
+        $annotation = $this->findAnnotation($annotations, OA\FloatValue::class);
+
+        if ($annotation instanceof OA\FloatValue) {
             if ($annotation->minimum !== null) {
                 $builder = $builder->withMinimum($annotation->minimum);
             }
@@ -144,8 +146,8 @@ final class AnnotationPropertySchemaDecorator extends AbstractAnnotationSchemaDe
             return $this->decorateEnumSchemaBuilder($builder, $annotations);
         }
 
-        if ($annotation = $this->findAnnotation($annotations, OA\StringValue::class)) {
-            /** @var OA\StringValue $annotation */
+        $annotation = $this->findAnnotation($annotations, OA\StringValue::class);
+        if ($annotation instanceof OA\StringValue) {
             if ($annotation->minLength !== null) {
                 $builder = $builder->withMinLength($annotation->minLength);
             }
@@ -167,8 +169,8 @@ final class AnnotationPropertySchemaDecorator extends AbstractAnnotationSchemaDe
         EnumSchemaBuilder $builder,
         array $annotations
     ): AbstractSchemaBuilder {
-        if ($annotation = $this->findAnnotation($annotations, OA\EnumValue::class)) {
-            /** @var OA\EnumValue $annotation */
+        $annotation = $this->findAnnotation($annotations, OA\EnumValue::class);
+        if ($annotation instanceof OA\EnumValue) {
             if ($annotation->enum) {
                 $builder = $builder->withEnum($annotation->enum);
             }
@@ -181,8 +183,8 @@ final class AnnotationPropertySchemaDecorator extends AbstractAnnotationSchemaDe
         ArraySchemaBuilder $builder,
         array $annotations
     ): AbstractSchemaBuilder {
-        if ($annotation = $this->findAnnotation($annotations, OA\ArrayValue::class)) {
-            /** @var OA\ArrayValue $annotation */
+        $annotation = $this->findAnnotation($annotations, OA\ArrayValue::class);
+        if ($annotation instanceof OA\ArrayValue) {
             if ($annotation->minItems !== null) {
                 $builder = $builder->withMinItems($annotation->minItems);
             }
@@ -208,11 +210,13 @@ final class AnnotationPropertySchemaDecorator extends AbstractAnnotationSchemaDe
         HashmapSchemaBuilder $builder,
         array $annotations
     ): AbstractSchemaBuilder {
-        if ($annotation = $this->findAnnotation($annotations, OA\HashmapValue::class)) {
-            /** @var OA\HashmapValue $annotation */
+        $annotation = $this->findAnnotation($annotations, OA\HashmapValue::class);
+
+        if ($annotation instanceof OA\HashmapValue) {
             if ($annotation->requiredProperties !== null) {
                 $builder = $builder->withRequiredProperties($annotation->requiredProperties);
             }
+
             if ($annotation->itemsSchema !== null && ($itemsBuilder = $builder->getItemsSchemaBuilder())) {
                 $itemsBuilder = $this->decoratePropertySchemaBuilderFromAnnotations(
                     $itemsBuilder,
@@ -229,23 +233,26 @@ final class AnnotationPropertySchemaDecorator extends AbstractAnnotationSchemaDe
         UnionSchemaBuilder $builder,
         array $annotations
     ): AbstractSchemaBuilder {
-        if ($annotation = $this->findAnnotation($annotations, OA\Union::class)) {
+        $annotation = $this->findAnnotation($annotations, OA\Union::class);
+
+        if ($annotation) {
             /** @var OA\Union $annotation */
             $possibleSchemaBuilders = $builder->getPossibleSchemaBuilders();
             $annotatedBuilders = [];
             $typeAnnotations = $annotation->types ?? [];
             while (
-                ($typeAnnotation = \array_shift($typeAnnotations))
-                && ($possibleSchemaBuilder = \array_shift($possibleSchemaBuilders))
+                ($typeAnnotation = array_shift($typeAnnotations))
+                && ($possibleSchemaBuilder = array_shift($possibleSchemaBuilders))
             ) {
                 $annotatedBuilders[] = $this->decoratePropertySchemaBuilderFromAnnotations(
                     $possibleSchemaBuilder,
                     [$typeAnnotation]
                 );
             }
-            $possibleSchemaBuilders = \array_merge($annotatedBuilders, $possibleSchemaBuilders);
+            $possibleSchemaBuilders = array_merge($annotatedBuilders, $possibleSchemaBuilders);
 
-            if ($discriminator = $annotation->discriminator) {
+            $discriminator = $annotation->discriminator;
+            if ($discriminator) {
                 foreach ($possibleSchemaBuilders as $possibleSchemaBuilder) {
                     if (
                         ! $possibleSchemaBuilder instanceof ObjectSchemaBuilder
@@ -262,7 +269,8 @@ final class AnnotationPropertySchemaDecorator extends AbstractAnnotationSchemaDe
             if ($annotation->mapping !== null) {
                 $possibleSchemaBuildersMap = [];
                 foreach ($possibleSchemaBuilders as $possibleSchemaBuilder) {
-                    if ($schemaName = $possibleSchemaBuilder->getSchemaName()) {
+                    $schemaName = $possibleSchemaBuilder->getSchemaName();
+                    if ($schemaName) {
                         $possibleSchemaBuildersMap[$schemaName] = $possibleSchemaBuilder;
                     } else {
                         throw new LogicException(

--- a/src/SchemaBuilder/Decorator/PropertyDecorator/AnnotationPropertySchemaDecorator.php
+++ b/src/SchemaBuilder/Decorator/PropertyDecorator/AnnotationPropertySchemaDecorator.php
@@ -5,7 +5,14 @@ declare(strict_types=1);
 namespace ScrumWorks\OpenApiSchema\SchemaBuilder\Decorator\PropertyDecorator;
 
 use ReflectionProperty;
-use ScrumWorks\OpenApiSchema\Annotation as OA;
+use ScrumWorks\OpenApiSchema\Annotation\ArrayValue;
+use ScrumWorks\OpenApiSchema\Annotation\EnumValue;
+use ScrumWorks\OpenApiSchema\Annotation\FloatValue;
+use ScrumWorks\OpenApiSchema\Annotation\HashmapValue;
+use ScrumWorks\OpenApiSchema\Annotation\IntegerValue;
+use ScrumWorks\OpenApiSchema\Annotation\Property;
+use ScrumWorks\OpenApiSchema\Annotation\StringValue;
+use ScrumWorks\OpenApiSchema\Annotation\Union;
 use ScrumWorks\OpenApiSchema\Exception\LogicException;
 use ScrumWorks\OpenApiSchema\SchemaBuilder\Decorator\AbstractAnnotationSchemaDecorator;
 use ScrumWorks\OpenApiSchema\SchemaBuilder\Decorator\PropertySchemaDecoratorInterface;
@@ -68,9 +75,9 @@ final class AnnotationPropertySchemaDecorator extends AbstractAnnotationSchemaDe
         AbstractSchemaBuilder $builder,
         array $annotations
     ): AbstractSchemaBuilder {
-        $annotation = $this->findAnnotation($annotations, OA\Property ::class, false);
+        $annotation = $this->findAnnotation($annotations, Property ::class, false);
 
-        if ($annotation instanceof OA\Property) {
+        if ($annotation instanceof Property) {
             if ($annotation->description !== null) {
                 $builder = $builder->withDescription($annotation->description);
             }
@@ -87,8 +94,9 @@ final class AnnotationPropertySchemaDecorator extends AbstractAnnotationSchemaDe
         IntegerSchemaBuilder $builder,
         array $annotations
     ): AbstractSchemaBuilder {
-        $annotation = $this->findAnnotation($annotations, OA\IntegerValue::class);
-        if ($annotation instanceof OA\IntegerValue) {
+        $annotation = $this->findAnnotation($annotations, IntegerValue::class);
+
+        if ($annotation instanceof IntegerValue) {
             if ($annotation->minimum !== null) {
                 $builder = $builder->withMinimum($annotation->minimum);
             }
@@ -113,9 +121,9 @@ final class AnnotationPropertySchemaDecorator extends AbstractAnnotationSchemaDe
         FloatSchemaBuilder $builder,
         array $annotations
     ): AbstractSchemaBuilder {
-        $annotation = $this->findAnnotation($annotations, OA\FloatValue::class);
+        $annotation = $this->findAnnotation($annotations, FloatValue::class);
 
-        if ($annotation instanceof OA\FloatValue) {
+        if ($annotation instanceof FloatValue) {
             if ($annotation->minimum !== null) {
                 $builder = $builder->withMinimum($annotation->minimum);
             }
@@ -140,14 +148,14 @@ final class AnnotationPropertySchemaDecorator extends AbstractAnnotationSchemaDe
         StringSchemaBuilder $builder,
         array $annotations
     ): AbstractSchemaBuilder {
-        if ($this->findAnnotation($annotations, OA\EnumValue::class, false)) {
+        if ($this->findAnnotation($annotations, EnumValue::class, false)) {
             $builder = (new EnumSchemaBuilder())
                 ->withNullable($builder->isNullable());
             return $this->decorateEnumSchemaBuilder($builder, $annotations);
         }
 
-        $annotation = $this->findAnnotation($annotations, OA\StringValue::class);
-        if ($annotation instanceof OA\StringValue) {
+        $annotation = $this->findAnnotation($annotations, StringValue::class);
+        if ($annotation instanceof StringValue) {
             if ($annotation->minLength !== null) {
                 $builder = $builder->withMinLength($annotation->minLength);
             }
@@ -169,8 +177,8 @@ final class AnnotationPropertySchemaDecorator extends AbstractAnnotationSchemaDe
         EnumSchemaBuilder $builder,
         array $annotations
     ): AbstractSchemaBuilder {
-        $annotation = $this->findAnnotation($annotations, OA\EnumValue::class);
-        if ($annotation instanceof OA\EnumValue) {
+        $annotation = $this->findAnnotation($annotations, EnumValue::class);
+        if ($annotation instanceof EnumValue) {
             if ($annotation->enum) {
                 $builder = $builder->withEnum($annotation->enum);
             }
@@ -183,8 +191,9 @@ final class AnnotationPropertySchemaDecorator extends AbstractAnnotationSchemaDe
         ArraySchemaBuilder $builder,
         array $annotations
     ): AbstractSchemaBuilder {
-        $annotation = $this->findAnnotation($annotations, OA\ArrayValue::class);
-        if ($annotation instanceof OA\ArrayValue) {
+        $annotation = $this->findAnnotation($annotations, ArrayValue::class);
+
+        if ($annotation instanceof ArrayValue) {
             if ($annotation->minItems !== null) {
                 $builder = $builder->withMinItems($annotation->minItems);
             }
@@ -194,7 +203,9 @@ final class AnnotationPropertySchemaDecorator extends AbstractAnnotationSchemaDe
             if ($annotation->uniqueItems !== null) {
                 $builder = $builder->withUniqueItems($annotation->uniqueItems);
             }
-            if ($annotation->itemsSchema !== null && ($itemsBuilder = $builder->getItemsSchemaBuilder())) {
+
+            $itemsBuilder = $builder->getItemsSchemaBuilder();
+            if ($annotation->itemsSchema !== null && $itemsBuilder) {
                 $itemsBuilder = $this->decoratePropertySchemaBuilderFromAnnotations(
                     $itemsBuilder,
                     [$annotation->itemsSchema]
@@ -210,14 +221,16 @@ final class AnnotationPropertySchemaDecorator extends AbstractAnnotationSchemaDe
         HashmapSchemaBuilder $builder,
         array $annotations
     ): AbstractSchemaBuilder {
-        $annotation = $this->findAnnotation($annotations, OA\HashmapValue::class);
+        $annotation = $this->findAnnotation($annotations, HashmapValue::class);
 
-        if ($annotation instanceof OA\HashmapValue) {
+        if ($annotation instanceof HashmapValue) {
             if ($annotation->requiredProperties !== null) {
                 $builder = $builder->withRequiredProperties($annotation->requiredProperties);
             }
 
-            if ($annotation->itemsSchema !== null && ($itemsBuilder = $builder->getItemsSchemaBuilder())) {
+            $itemsBuilder = $builder->getItemsSchemaBuilder();
+
+            if ($annotation->itemsSchema !== null && $itemsBuilder) {
                 $itemsBuilder = $this->decoratePropertySchemaBuilderFromAnnotations(
                     $itemsBuilder,
                     [$annotation->itemsSchema]
@@ -233,10 +246,9 @@ final class AnnotationPropertySchemaDecorator extends AbstractAnnotationSchemaDe
         UnionSchemaBuilder $builder,
         array $annotations
     ): AbstractSchemaBuilder {
-        $annotation = $this->findAnnotation($annotations, OA\Union::class);
+        $annotation = $this->findAnnotation($annotations, Union::class);
 
-        if ($annotation) {
-            /** @var OA\Union $annotation */
+        if ($annotation instanceof Union) {
             $possibleSchemaBuilders = $builder->getPossibleSchemaBuilders();
             $annotatedBuilders = [];
             $typeAnnotations = $annotation->types ?? [];

--- a/src/SchemaBuilder/SchemaBuilderFactory.php
+++ b/src/SchemaBuilder/SchemaBuilderFactory.php
@@ -41,7 +41,7 @@ class SchemaBuilderFactory
 
     public function createForClass(string $class): AbstractSchemaBuilder
     {
-        if (! \class_exists($class) && ! \interface_exists($class)) {
+        if (! class_exists($class) && ! interface_exists($class)) {
             throw new LogicException("Class or interface '${class}' does not exist");
         }
 
@@ -76,7 +76,7 @@ class SchemaBuilderFactory
         } elseif ($variableType instanceof UnionVariableType) {
             $schemaBuilder = $this->createSchemaBuilderFromUnion($variableType);
         } else {
-            throw new LogicException(\sprintf(
+            throw new LogicException(sprintf(
                 "Unprocessable VariableTypeInterface '%s' (class %s)",
                 $variableType->getTypeName(),
                 \get_class($variableType)
@@ -113,7 +113,7 @@ class SchemaBuilderFactory
                 $schemaBuilder = new StringSchemaBuilder();
                 break;
             default:
-                throw new LogicException(\sprintf("Unknown scalar type '%s'", $variableType->getType()));
+                throw new LogicException(sprintf("Unknown scalar type '%s'", $variableType->getType()));
         }
 
         return $schemaBuilder;
@@ -148,7 +148,7 @@ class SchemaBuilderFactory
 
     protected function createSchemaBuilderFromUnion(UnionVariableType $variableType): AbstractSchemaBuilder
     {
-        return new UnionSchemaBuilder(\array_map(
+        return new UnionSchemaBuilder(array_map(
             fn (VariableTypeInterface $type) => $this->createForVariableType($type),
             $variableType->getTypes()
         ));

--- a/src/Validation/Result/BreadCrumbPath.php
+++ b/src/Validation/Result/BreadCrumbPath.php
@@ -15,7 +15,7 @@ final class BreadCrumbPath implements BreadCrumbPathInterface
 
     public function __toString()
     {
-        return \implode('.', $this->breadCrumbs);
+        return implode('.', $this->breadCrumbs);
     }
 
     public function withNextBreadCrumb(string $breadCrumb): self
@@ -28,7 +28,7 @@ final class BreadCrumbPath implements BreadCrumbPathInterface
     public function withIndex(int $index): self
     {
         $breadCrumbPath = clone $this;
-        $breadCrumbPath->breadCrumbs[] = (string) \array_pop($breadCrumbPath->breadCrumbs) . "[${index}]";
+        $breadCrumbPath->breadCrumbs[] = (string) array_pop($breadCrumbPath->breadCrumbs) . "[${index}]";
         return $breadCrumbPath;
     }
 }

--- a/src/Validation/Result/ValidationResultBuilder.php
+++ b/src/Validation/Result/ValidationResultBuilder.php
@@ -149,12 +149,12 @@ class ValidationResultBuilder
 
     public function createResult(): ValidationResultInterface
     {
-        return new ValidationResult(\array_values($this->validityViolations));
+        return new ValidationResult(array_values($this->validityViolations));
     }
 
     protected function addViolation(ValidityViolationInterface $validityViolation): self
     {
-        $this->validityViolations[\serialize($validityViolation)] = $validityViolation;
+        $this->validityViolations[serialize($validityViolation)] = $validityViolation;
         return $this;
     }
 }

--- a/src/Validation/Result/ValidityViolationFactory.php
+++ b/src/Validation/Result/ValidityViolationFactory.php
@@ -55,7 +55,7 @@ final class ValidityViolationFactory implements ValidityViolationFactoryInterfac
         array $choices,
         BreadCrumbPathInterface $breadCrumbPath
     ): ValidityViolationInterface {
-        $choicesString = $choices ? ("'" . \implode("', '", $choices) . "'") : '';
+        $choicesString = $choices ? ("'" . implode("', '", $choices) . "'") : '';
         return new ValidityViolation(1008, 'Value has to be one of [%s].', [$choicesString], $breadCrumbPath);
     }
 

--- a/src/Validation/Validator/AbstractNumberValidator.php
+++ b/src/Validation/Validator/AbstractNumberValidator.php
@@ -36,7 +36,7 @@ abstract class AbstractNumberValidator extends AbstractValidator
             $resultBuilder->addMaximumViolation($max, $breadCrumbPath);
         }
 
-        if ($multipleOf !== null && \abs(0 - \fmod($data, $multipleOf)) > 0.0001) {
+        if ($multipleOf !== null && abs(0 - fmod($data, $multipleOf)) > 0.0001) {
             $resultBuilder->addMultipleOfViolation($multipleOf, $breadCrumbPath);
         }
     }

--- a/src/Validation/Validator/ArrayValidator.php
+++ b/src/Validation/Validator/ArrayValidator.php
@@ -44,13 +44,17 @@ final class ArrayValidator extends AbstractValidator
         }
 
         $count = \count($data);
-        if (($min = $this->schema->getMinItems()) !== null && $min > $count) {
+
+        $min = $this->schema->getMinItems();
+        if ($min !== null && $min > $count) {
             $resultBuilder->addMinItemsViolation($min, $breadCrumbPath);
         }
-        if (($max = $this->schema->getMaxItems()) !== null && $max < $count) {
+
+        $max = $this->schema->getMaxItems();
+        if ($max !== null && $max < $count) {
             $resultBuilder->addMaxItemsViolation($max, $breadCrumbPath);
         }
-        if (($this->schema->getUniqueItems() ?? false) && $count !== \count(\array_unique($data))) {
+        if (($this->schema->getUniqueItems() ?? false) && $count !== \count(array_unique($data))) {
             $resultBuilder->addUniqueViolation($breadCrumbPath);
         }
 
@@ -73,10 +77,13 @@ final class ArrayValidator extends AbstractValidator
 
         $resultBuilder->addTypeViolation('array', $breadCrumbPath);
 
-        if (($min = $this->schema->getMinItems()) !== null) {
+        $min = $this->schema->getMinItems();
+        if ($min !== null) {
             $resultBuilder->addMinItemsViolation($min, $breadCrumbPath);
         }
-        if (($max = $this->schema->getMaxItems()) !== null) {
+
+        $max = $this->schema->getMaxItems();
+        if ($max !== null) {
             $resultBuilder->addMaxItemsViolation($max, $breadCrumbPath);
         }
         if ($this->schema->getUniqueItems() ?? false) {

--- a/src/Validation/Validator/EnumValidator.php
+++ b/src/Validation/Validator/EnumValidator.php
@@ -35,7 +35,7 @@ final class EnumValidator extends AbstractValidator
 
         if (! \is_string($data)) {
             $resultBuilder->addTypeViolation('string', $breadCrumbPath);
-        } elseif (! \in_array($data, $this->schema->getEnum())) {
+        } elseif (! \in_array($data, $this->schema->getEnum(), true)) {
             $resultBuilder->addEnumViolation($this->schema->getEnum(), $breadCrumbPath);
         }
     }

--- a/src/Validation/Validator/HashmapValidator.php
+++ b/src/Validation/Validator/HashmapValidator.php
@@ -44,7 +44,7 @@ final class HashmapValidator extends AbstractValidator
         }
 
         foreach ($this->schema->getRequiredProperties() as $requiredProperty) {
-            if (! \property_exists($data, $requiredProperty)) {
+            if (! property_exists($data, $requiredProperty)) {
                 $resultBuilder->addRequiredViolation($breadCrumbPath->withNextBreadCrumb($requiredProperty));
             }
         }

--- a/src/Validation/Validator/ObjectValidator.php
+++ b/src/Validation/Validator/ObjectValidator.php
@@ -44,7 +44,7 @@ final class ObjectValidator extends AbstractValidator
         }
 
         foreach ($this->schema->getRequiredProperties() as $requiredProperty) {
-            if (! \property_exists($data, $requiredProperty)) {
+            if (! property_exists($data, $requiredProperty)) {
                 $resultBuilder->addRequiredViolation($breadCrumbPath->withNextBreadCrumb($requiredProperty));
             }
         }
@@ -58,7 +58,8 @@ final class ObjectValidator extends AbstractValidator
                 $propertyValidationResult = $this->valueValidator->validate(
                     $propertySchemas[$propertyName],
                     $propertyData,
-                    $breadCrumbPath->withNextBreadCrumb($propertyName))
+                    $breadCrumbPath->withNextBreadCrumb($propertyName)
+                )
                 ;
                 $resultBuilder->mergeResult($propertyValidationResult);
             }

--- a/src/Validation/Validator/StringValidator.php
+++ b/src/Validation/Validator/StringValidator.php
@@ -47,24 +47,28 @@ final class StringValidator extends AbstractValidator
             return;
         }
 
-        $strlen = $this->schema->getFormat() === 'binary' ? \strlen($data) : \mb_strlen($data);
+        $strlen = $this->schema->getFormat() === 'binary' ? \strlen($data) : mb_strlen($data);
 
-        if (($minLength = $this->schema->getMinLength()) !== null && $minLength > $strlen) {
+        $minLength = $this->schema->getMinLength();
+        if ($minLength !== null && $minLength > $strlen) {
             $resultBuilder->addMinLengthViolation($minLength, $breadCrumbPath);
         }
-        if (($maxLength = $this->schema->getMaxLength()) !== null && $maxLength < $strlen) {
+
+        $maxLength = $this->schema->getMaxLength();
+        if ($maxLength !== null && $maxLength < $strlen) {
             $resultBuilder->addMaxLengthViolation($maxLength, $breadCrumbPath);
         }
-        if (($pattern = $this->schema->getPattern()) !== null) {
-            $escapedPattern = \str_replace('~', '\\~', $pattern);
+
+        $pattern = $this->schema->getPattern();
+        if ($pattern !== null) {
+            $escapedPattern = str_replace('~', '\\~', $pattern);
             if (! Strings::match($data, "~${escapedPattern}~")) {
                 $resultBuilder->addPatternViolation($pattern, $breadCrumbPath);
             }
         }
-        if (
-            ($format = $this->schema->getFormat()) !== null
-            && ! $this->hasValidFormat($format, $data)
-        ) {
+
+        $format = $this->schema->getFormat();
+        if ($format !== null && ! $this->hasValidFormat($format, $data)) {
             $resultBuilder->addFormatViolation($format, $breadCrumbPath);
         }
     }
@@ -76,16 +80,24 @@ final class StringValidator extends AbstractValidator
         parent::collectPossibleViolationExamples($resultBuilder, $breadCrumbPath);
 
         $resultBuilder->addTypeViolation('string', $breadCrumbPath);
-        if (($minLength = $this->schema->getMinLength()) !== null) {
+
+        $minLength = $this->schema->getMinLength();
+        if ($minLength !== null) {
             $resultBuilder->addMinLengthViolation($minLength, $breadCrumbPath);
         }
-        if (($maxLength = $this->schema->getMaxLength()) !== null) {
+
+        $maxLength = $this->schema->getMaxLength();
+        if ($maxLength !== null) {
             $resultBuilder->addMaxLengthViolation($maxLength, $breadCrumbPath);
         }
-        if (($pattern = $this->schema->getPattern()) !== null) {
+
+        $pattern = $this->schema->getPattern();
+        if ($pattern !== null) {
             $resultBuilder->addPatternViolation($pattern, $breadCrumbPath);
         }
-        if (($format = $this->schema->getFormat()) !== null) {
+
+        $format = $this->schema->getFormat();
+        if ($format !== null) {
             $resultBuilder->addFormatViolation($format, $breadCrumbPath);
         }
     }

--- a/src/Validation/Validator/UnionValidator.php
+++ b/src/Validation/Validator/UnionValidator.php
@@ -41,11 +41,11 @@ final class UnionValidator extends AbstractValidator
         if ($discriminatorName = $this->schema->getDiscriminatorPropertyName()) {
             if (! \is_object($data)) {
                 $resultBuilder->addTypeViolation('object', $breadCrumbPath);
-            } elseif (! \property_exists($data, $discriminatorName)) {
+            } elseif (! property_exists($data, $discriminatorName)) {
                 $resultBuilder->addRequiredViolation($breadCrumbPath->withNextBreadCrumb($discriminatorName));
             } elseif (! ($discriminatorSchema = $this->schema->getPossibleSchemas()[$data->{$discriminatorName}] ?? null)) {
                 $resultBuilder->addEnumViolation(
-                    \array_keys($this->schema->getPossibleSchemas()),
+                    array_keys($this->schema->getPossibleSchemas()),
                     $breadCrumbPath->withNextBreadCrumb($discriminatorName)
                 );
             } else {
@@ -80,11 +80,12 @@ final class UnionValidator extends AbstractValidator
     ): void {
         parent::collectPossibleViolationExamples($resultBuilder, $breadCrumbPath);
 
-        if ($discriminatorName = $this->schema->getDiscriminatorPropertyName()) {
+        $discriminatorName = $this->schema->getDiscriminatorPropertyName();
+        if ($discriminatorName) {
             $resultBuilder->addTypeViolation('object', $breadCrumbPath);
             $resultBuilder->addRequiredViolation($breadCrumbPath->withNextBreadCrumb($discriminatorName));
             $resultBuilder->addEnumViolation(
-                \array_keys($this->schema->getPossibleSchemas()),
+                array_keys($this->schema->getPossibleSchemas()),
                 $breadCrumbPath->withNextBreadCrumb($discriminatorName)
             );
             foreach ($this->schema->getPossibleSchemas() as $schema) {

--- a/src/ValueSchema/ArraySchema.php
+++ b/src/ValueSchema/ArraySchema.php
@@ -56,13 +56,13 @@ final class ArraySchema extends AbstractValueSchema
     protected function validate(): void
     {
         if ($this->minItems !== null && $this->minItems < 0) {
-            throw new InvalidArgumentException(\sprintf("Invalid value %d for argument 'minItems'", $this->minItems));
+            throw new InvalidArgumentException(sprintf("Invalid value %d for argument 'minItems'", $this->minItems));
         }
         if ($this->maxItems !== null && $this->maxItems < 0) {
-            throw new InvalidArgumentException(\sprintf("Invalid value %d for argument 'maxItems'", $this->maxItems));
+            throw new InvalidArgumentException(sprintf("Invalid value %d for argument 'maxItems'", $this->maxItems));
         }
         if ($this->minItems !== null && $this->maxItems !== null && $this->maxItems < $this->minItems) {
-            throw new InvalidArgumentException(\sprintf("Invalid value %d for argument 'maxItems'", $this->maxItems));
+            throw new InvalidArgumentException(sprintf("Invalid value %d for argument 'maxItems'", $this->maxItems));
         }
     }
 }

--- a/src/ValueSchema/Builder/ObjectSchemaBuilder.php
+++ b/src/ValueSchema/Builder/ObjectSchemaBuilder.php
@@ -56,7 +56,7 @@ final class ObjectSchemaBuilder extends AbstractSchemaBuilder
 
     public function build(): ObjectSchema
     {
-        $propertySchemas = \array_map(
+        $propertySchemas = array_map(
             static fn (AbstractSchemaBuilder $builder) => $builder->build(),
             $this->propertiesSchemaBuilders
         );

--- a/src/ValueSchema/Builder/UnionSchemaBuilder.php
+++ b/src/ValueSchema/Builder/UnionSchemaBuilder.php
@@ -57,7 +57,7 @@ final class UnionSchemaBuilder extends AbstractSchemaBuilder
 
     public function build(): UnionSchema
     {
-        $possibleSchemas = \array_map(
+        $possibleSchemas = array_map(
             static fn (AbstractSchemaBuilder $builder) => $builder->build(),
             $this->possibleSchemaBuilders
         );

--- a/src/ValueSchema/FloatSchema.php
+++ b/src/ValueSchema/FloatSchema.php
@@ -65,13 +65,13 @@ final class FloatSchema extends AbstractValueSchema
     protected function validate(): void
     {
         if ($this->minimum !== null && $this->minimum < 0) {
-            throw new InvalidArgumentException(\sprintf("Invalid value %d for argument 'minimum'", $this->minimum));
+            throw new InvalidArgumentException(sprintf("Invalid value %d for argument 'minimum'", $this->minimum));
         }
         if ($this->maximum !== null && $this->maximum < 0) {
-            throw new InvalidArgumentException(\sprintf("Invalid value %d for argument 'maximum'", $this->maximum));
+            throw new InvalidArgumentException(sprintf("Invalid value %d for argument 'maximum'", $this->maximum));
         }
         if ($this->minimum !== null && $this->maximum !== null && $this->maximum < $this->minimum) {
-            throw new InvalidArgumentException(\sprintf("Invalid value %d for argument 'maximum'", $this->maximum));
+            throw new InvalidArgumentException(sprintf("Invalid value %d for argument 'maximum'", $this->maximum));
         }
         if ($this->minimum === null && $this->exclusiveMinimum !== null) {
             throw new InvalidArgumentException("Can't set 'exclusiveMinimum' without 'minimum' argument");

--- a/src/ValueSchema/IntegerSchema.php
+++ b/src/ValueSchema/IntegerSchema.php
@@ -65,13 +65,13 @@ final class IntegerSchema extends AbstractValueSchema
     protected function validate(): void
     {
         if ($this->minimum !== null && $this->minimum < 0) {
-            throw new InvalidArgumentException(\sprintf("Invalid value %d for argument 'minimum'", $this->minimum));
+            throw new InvalidArgumentException(sprintf("Invalid value %d for argument 'minimum'", $this->minimum));
         }
         if ($this->maximum !== null && $this->maximum < 0) {
-            throw new InvalidArgumentException(\sprintf("Invalid value %d for argument 'maximum'", $this->maximum));
+            throw new InvalidArgumentException(sprintf("Invalid value %d for argument 'maximum'", $this->maximum));
         }
         if ($this->minimum !== null && $this->maximum !== null && $this->maximum < $this->minimum) {
-            throw new InvalidArgumentException(\sprintf("Invalid value %d for argument 'maximum'", $this->maximum));
+            throw new InvalidArgumentException(sprintf("Invalid value %d for argument 'maximum'", $this->maximum));
         }
         if ($this->minimum === null && $this->exclusiveMinimum !== null) {
             throw new InvalidArgumentException("Can't set 'exclusiveMinimum' without 'minimum' argument");

--- a/src/ValueSchema/ObjectSchema.php
+++ b/src/ValueSchema/ObjectSchema.php
@@ -48,7 +48,7 @@ final class ObjectSchema extends AbstractValueSchema
     public function getPropertySchema(string $property): ValueSchemaInterface
     {
         if (! isset($this->propertiesSchemas[$property])) {
-            throw new InvalidArgumentException(\sprintf("Property '%s' doesn't exists", $property));
+            throw new InvalidArgumentException(sprintf("Property '%s' doesn't exists", $property));
         }
         return $this->propertiesSchemas[$property];
     }
@@ -66,10 +66,10 @@ final class ObjectSchema extends AbstractValueSchema
         $properties = [];
         foreach ($this->propertiesSchemas as $property => $schema) {
             if (! \is_string($property)) {
-                throw new InvalidArgumentException(\sprintf("Property key '%s' must be string", $property));
+                throw new InvalidArgumentException(sprintf("Property key '%s' must be string", $property));
             }
             if (! ($schema instanceof ValueSchemaInterface)) {
-                throw new InvalidArgumentException(\sprintf(
+                throw new InvalidArgumentException(sprintf(
                     'Invalid schema (must be instance of %s)',
                     ValueSchemaInterface::class
                 ));
@@ -77,11 +77,11 @@ final class ObjectSchema extends AbstractValueSchema
             $properties[] = $property;
         }
 
-        $excludingRequiredProperties = \array_diff($this->requiredProperties, $properties);
+        $excludingRequiredProperties = array_diff($this->requiredProperties, $properties);
         if ($excludingRequiredProperties) {
-            throw new InvalidArgumentException(\sprintf(
+            throw new InvalidArgumentException(sprintf(
                 'Required properties are not listed in schema (%s)',
-                \implode(', ', $excludingRequiredProperties)
+                implode(', ', $excludingRequiredProperties)
             ));
         }
     }

--- a/src/ValueSchema/StringSchema.php
+++ b/src/ValueSchema/StringSchema.php
@@ -56,13 +56,13 @@ final class StringSchema extends AbstractValueSchema
     protected function validate(): void
     {
         if ($this->minLength !== null && $this->minLength < 0) {
-            throw new InvalidArgumentException(\sprintf("Invalid value %d for argument 'minLength'", $this->minLength));
+            throw new InvalidArgumentException(sprintf("Invalid value %d for argument 'minLength'", $this->minLength));
         }
         if ($this->maxLength !== null && $this->maxLength < 0) {
-            throw new InvalidArgumentException(\sprintf("Invalid value %d for argument 'maxLength'", $this->maxLength));
+            throw new InvalidArgumentException(sprintf("Invalid value %d for argument 'maxLength'", $this->maxLength));
         }
         if ($this->minLength !== null && $this->maxLength !== null && $this->maxLength < $this->minLength) {
-            throw new InvalidArgumentException(\sprintf("Invalid value %d for argument 'maxLength'", $this->maxLength));
+            throw new InvalidArgumentException(sprintf("Invalid value %d for argument 'maxLength'", $this->maxLength));
         }
         // TODO assert for $pattern
         // TODO $format and $pattern is probably exclusive

--- a/src/ValueSchema/UnionSchema.php
+++ b/src/ValueSchema/UnionSchema.php
@@ -29,7 +29,7 @@ final class UnionSchema extends AbstractValueSchema
 
         parent::__construct($nullable, $description);
 
-        $this->nullable = $this->nullable || \array_reduce(
+        $this->nullable = $this->nullable || array_reduce(
             $possibleSchemas,
             static fn (bool $carry, ValueSchemaInterface $type) => $carry || $type->isNullable(),
             false
@@ -57,7 +57,7 @@ final class UnionSchema extends AbstractValueSchema
 
         foreach ($this->possibleSchemas as $schema) {
             if (! ($schema instanceof ValueSchemaInterface)) {
-                throw new InvalidArgumentException(\sprintf(
+                throw new InvalidArgumentException(sprintf(
                     'Invalid schema (must be instance of %s)',
                     ValueSchemaInterface::class
                 ));

--- a/tests/OpenApiTranslatorTest.php
+++ b/tests/OpenApiTranslatorTest.php
@@ -200,7 +200,7 @@ class OpenApiTranslatorTest extends TestCase
                 ],
             ],
             'array:full' => [
-                new ArraySchema(new StringSchema(), 1, 3, true, false, 'array', ),
+                new ArraySchema(new StringSchema(), 1, 3, true, false, 'array',),
                 [
                     'type' => 'array',
                     'items' => [

--- a/tests/SchemaParserTest.php
+++ b/tests/SchemaParserTest.php
@@ -226,6 +226,7 @@ class SchemaParserTest extends TestCase
         $this->assertInstanceOf(UnionSchema::class, $objectUnionSchema);
         $this->assertFalse($objectUnionSchema->isNullable());
         $this->assertSame('type', $objectUnionSchema->getDiscriminatorPropertyName());
+
         $this->assertEquals([
             'a' => new ObjectSchema([
                 'type' => new StringSchema(),

--- a/tests/Validation/IntegrationTest.php
+++ b/tests/Validation/IntegrationTest.php
@@ -17,7 +17,7 @@ class IntegrationTest extends TestCase
 
     public function testValid(): void
     {
-        $data = \json_decode('
+        $data = json_decode('
             {
                 "cislo":123,
                 "retezec":"hello",
@@ -44,7 +44,7 @@ class IntegrationTest extends TestCase
 
     public function testInvalid(): void
     {
-        $data = \json_decode('
+        $data = json_decode('
             {
                 "cislo":123,
                 "retezec":"hello",

--- a/tests/Validation/_Support/AssertViolationTrait.php
+++ b/tests/Validation/_Support/AssertViolationTrait.php
@@ -16,7 +16,7 @@ trait AssertViolationTrait
      */
     public function assertViolations(array $expectedViolations, array $actualViolations): void
     {
-        $differentViolationCountMsg = \implode("\n", \array_map(
+        $differentViolationCountMsg = implode("\n", array_map(
             static fn (ValidityViolation $actualViolation) => $actualViolation->getMessageTemplate(),
             $actualViolations
         ));

--- a/tests/ValueSchema/Builder/HashmapSchemaBuilderTest.php
+++ b/tests/ValueSchema/Builder/HashmapSchemaBuilderTest.php
@@ -27,10 +27,7 @@ class HashmapSchemaBuilderTest extends TestCase
         $builder = $builder->withRequiredProperties(['property']);
         $builder = $builder->withDescription('hashmap');
         $builder = $builder->withNullable(true);
-        $this->assertEquals(
-            new HashmapSchema(new StringSchema(), ['property'], true, 'hashmap'),
-            $builder->build()
-        );
+        $this->assertEquals(new HashmapSchema(new StringSchema(), ['property'], true, 'hashmap'), $builder->build());
     }
 
     public function testMissingData(): void

--- a/tests/ValueSchema/Builder/IntegerSchemaBuilderTest.php
+++ b/tests/ValueSchema/Builder/IntegerSchemaBuilderTest.php
@@ -26,6 +26,7 @@ class IntegerSchemaBuilderTest extends TestCase
         $builder = $builder->withMultipleOf(2);
         $builder = $builder->withDescription('integer');
         $builder = $builder->withNullable(true);
+
         $this->assertEquals(new IntegerSchema(0, 10, true, false, 2, true, 'integer'), $builder->build());
     }
 }

--- a/tests/ValueSchema/Builder/ObjectSchemaBuilderTest.php
+++ b/tests/ValueSchema/Builder/ObjectSchemaBuilderTest.php
@@ -27,6 +27,7 @@ class ObjectSchemaBuilderTest extends TestCase
         $builder = $builder->withRequiredProperties(['property']);
         $builder = $builder->withDescription('object');
         $builder = $builder->withNullable(true);
+
         $this->assertEquals(
             new ObjectSchema([
                 'property' => new StringSchema(),

--- a/tests/ValueSchema/Builder/StringSchemaBuilderTest.php
+++ b/tests/ValueSchema/Builder/StringSchemaBuilderTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 use ScrumWorks\OpenApiSchema\ValueSchema\Builder\StringSchemaBuilder;
 use ScrumWorks\OpenApiSchema\ValueSchema\StringSchema;
 
-class StringSchemaBuilderTest extends TestCase
+final class StringSchemaBuilderTest extends TestCase
 {
     public function testMinimalBuild(): void
     {


### PR DESCRIPTION
Preparing for annotation + attribute support.

In Enum refactoring of our main repo, it often happens some annotations are not renamed during PHPStorm refactorings:

```php
* @OA\StringValue(minLength=Some::MIN_TITLE_LENGTH, maxLength=Some::MAX_TITLE_LENGTH)
```

Fortunatelly, it's always reported by advanced PHPStan rule from Symplify, but it shoult not happen. It requires manual update of annotation and can lead to edge-case renames that will be missed.

<br>

**This is the last docblock annotation we have in the project. It's time to move it to attribute and enjoy the full power of PHPStan rules on PHP code :+1:**

```diff
-* @OA\StringValue(minLength=Some::MIN_TITLE_LENGTH, maxLength=Some::MAX_TITLE_LENGTH)
+#[OA\StringValue(minLength=Some::MIN_TITLE_LENGTH, maxLength=Some::MAX_TITLE_LENGTH)]
```